### PR TITLE
feat: add Oauth2loginController exception handler with try-catch statement

### DIFF
--- a/src/main/java/com/dope/breaking/Security/SecurityController/Oauth2LoginController.java
+++ b/src/main/java/com/dope/breaking/Security/SecurityController/Oauth2LoginController.java
@@ -1,7 +1,9 @@
 package com.dope.breaking.Security.SecurityController;
 
 
+import ch.qos.logback.core.encoder.EchoEncoder;
 import com.dope.breaking.Security.Jwt.JwtTokenProvider;
+import com.dope.breaking.Security.UserInfoDto.InvalidAccessTokenResponse;
 import com.dope.breaking.Security.UserInfoDto.UserDto;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.service.UserService;
@@ -13,6 +15,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;
@@ -50,7 +53,7 @@ public class Oauth2LoginController {
 
         JSONObject jsonObject = (JSONObject) jsonParser.parse(profileResponse.getBody());
         log.info(jsonObject.toJSONString());
-        String userinfo =  jsonObject.get("response").toString();
+        String userinfo = jsonObject.get("response").toString();
         JSONObject jsonObject1 = (JSONObject) jsonParser.parse(userinfo);
         UserDto dto = new UserDto();
         dto.setFullname(jsonObject1.get("name").toString());
@@ -58,106 +61,145 @@ public class Oauth2LoginController {
         dto.setEmail(jsonObject1.get("email").toString());
         log.info(dto.toString());
         User user = userService.findByUsername(dto.getUsername()).orElse(null);
-        if(user == null){
+        if (user == null) {
             log.info("유저 정보가 없음");
             return ResponseEntity.status(200).body(dto);
-        }
-        else{
+        } else {
             log.info("유저 정보 있다.");
-            String accessjwt =  jwtTokenProvider.createAccessToken(user.getUsername());
+            String accessjwt = jwtTokenProvider.createAccessToken(user.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK );
+            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
         }
     }
 
 
     @PostMapping("/kakao")
     public ResponseEntity<?> kakaoOauthRedirect(@RequestBody Map<String, String> accessToken) throws ParseException {
-        HttpHeaders headers1 = new HttpHeaders();
+        HttpHeaders headers = new HttpHeaders();
         RestTemplate restTemplate = new RestTemplate();
         String token = accessToken.get("accessToken");
-        log.info("access token : {} ", token);
 
-        headers1.add("Authorization", "Bearer " +  token);
-        headers1.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.add("Authorization", "Bearer " + token);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
-        HttpEntity<HttpHeaders> kakaoRequest1 = new HttpEntity<>(headers1);
-
-        ResponseEntity<String> profileResponse = restTemplate.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.POST,
-                kakaoRequest1,
-                String.class
-        );
+        HttpEntity<HttpHeaders> kakaoRequest1 = new HttpEntity<>(headers);
+        ResponseEntity<String> kakaoUserinfo;
+        try {
+            kakaoUserinfo = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoRequest1,
+                    String.class
+            );
+        } catch (Exception e) {
+            log.info(e.toString());
+            InvalidAccessTokenResponse invalidAccessTokenResponse = new InvalidAccessTokenResponse();
+            invalidAccessTokenResponse.setAccessToken(token);
+            invalidAccessTokenResponse.setErrorMessage("유효하지 않은 AccessToken");
+            invalidAccessTokenResponse.setIdToken("Kakao에서는 필요하지 않는 Token");
+            return new ResponseEntity<InvalidAccessTokenResponse>(invalidAccessTokenResponse, HttpStatus.NOT_ACCEPTABLE); //유효하지 않은 토큰이라고 에러메시지 표출.
+        }
         JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(profileResponse.getBody());
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoUserinfo.getBody());
         log.info(jsonObject.toJSONString());
         UserDto dto = new UserDto();
         dto.setUsername(jsonObject.get("id").toString());
-        String kakao_account =  jsonObject.get("kakao_account").toString();
-
+        String kakao_account = jsonObject.get("kakao_account").toString();
         JSONObject jsonObject1 = (JSONObject) jsonParser.parse(kakao_account);
         log.info(jsonObject1.toJSONString());
-        dto.setEmail(jsonObject1.get("email").toString());
+        try {
+            dto.setEmail(jsonObject1.get("email").toString());
+        } catch (Exception e) {
+            log.info("이메일 정보를 불러올 수 없음");
+            dto.setEmail(null);
+        }
         String profile = jsonObject1.get("profile").toString();
         jsonObject1 = (JSONObject) jsonParser.parse(profile);
-        dto.setFullname(jsonObject1.get("nickname").toString());
-        log.info(dto.toString());
-        User user = userService.findByUsername(dto.getUsername()).orElse(null);
-        if(user == null){
-            log.info("유저 정보가 없음");
-            return ResponseEntity.status(200).body(dto);
+        try {
+            dto.setFullname(jsonObject1.get("nickname").toString());
+        } catch (Exception e) {
+            log.info("유저 이름을 불러올 수 없음");
+            dto.setFullname(null);
         }
-        else{
-            log.info("유저 정보가 있다.");
-            String accessjwt =  jwtTokenProvider.createAccessToken(user.getUsername());
+        try {
+            dto.setProfileImgURL(jsonObject1.get("profile_image_url").toString());
+        } catch (Exception e) {
+            log.info("기존 프로필 사진을 불러올 수 없음");
+            dto.setProfileImgURL(null);
+        }
+
+        if (!userService.existByUsername(dto.getUsername())) {
+            log.info("기존 유저 정보가 없음.");
+            return ResponseEntity.status(200).body(dto);
+        } else {
+            log.info("기존 유저 정보가 있음.");
+            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK );
+            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
         }
     }
 
 
     @PostMapping("/google")
     public ResponseEntity<?> googleOauthRedirect(@RequestBody Map<String, String> accessToken) throws ParseException {
-        HttpHeaders headers1 = new HttpHeaders();
+        HttpHeaders headers = new HttpHeaders();
         RestTemplate restTemplate = new RestTemplate();
         String token = accessToken.get("accessToken");
         String idtoken = accessToken.get("idToken");
-        log.info("access token : {} ", token);
 
-        headers1.add("Authorization", "Bearer " +  token);
+        headers.add("Authorization", "Bearer " + token);
+        ResponseEntity<String> GoogleUserinfo;
+        try {
+            HttpEntity profileRequest = new HttpEntity(headers);
+            GoogleUserinfo = restTemplate.exchange(
+                    "https://oauth2.googleapis.com/tokeninfo?id_token=" + idtoken,
+                    HttpMethod.GET,
+                    profileRequest,
+                    String.class
+            );
+        } catch (Exception e) {
+            log.info(e.toString());
+            InvalidAccessTokenResponse invalidAccessTokenResponse = new InvalidAccessTokenResponse();
+            invalidAccessTokenResponse.setAccessToken(token);
+            invalidAccessTokenResponse.setIdToken(idtoken);
+            invalidAccessTokenResponse.setErrorMessage("유효하지 않는 토큰 존재.");
 
-        HttpEntity profileRequest = new HttpEntity(headers1);
-        ResponseEntity<String> profileResponse = restTemplate.exchange(
-                "https://oauth2.googleapis.com/tokeninfo?id_token=" + idtoken,
-                HttpMethod.GET,
-                profileRequest,
-                String.class
-        );
-
+            return new ResponseEntity<InvalidAccessTokenResponse>(invalidAccessTokenResponse, HttpStatus.NOT_ACCEPTABLE); //유효하지 않은 토큰이라고 에러메시지 표출.
+        }
         JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(profileResponse.getBody());
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(GoogleUserinfo.getBody());
         log.info(jsonObject.toJSONString());
         UserDto dto = new UserDto();
         dto.setUsername(jsonObject.get("sub").toString());
-        dto.setEmail(jsonObject.get("email").toString());
-        dto.setFullname(jsonObject.get("given_name").toString());
-        User user = userService.findByUsername(dto.getUsername()).orElse(null);
-        if(user == null){
+        try {
+            dto.setEmail(jsonObject.get("email").toString());
+        } catch (Exception e) {
+            log.info("이메일 정보를 불러올 수 없음");
+            dto.setEmail(null);
+        }
+        try {
+            dto.setFullname(jsonObject.get("given_name").toString());
+        } catch (Exception e) {
+            log.info("유저 이름을 불러올 수 없음");
+            dto.setFullname(null);
+        }
+        try {
+            dto.setProfileImgURL(jsonObject.get("picture").toString());
+        } catch (Exception e) {
+            log.info("기존 프로필 사진을 불러올 수 없음");
+            dto.setProfileImgURL(null);
+        }
+        if (!userService.existByUsername(dto.getUsername())) {
             log.info("유저 정보가 없음");
             return ResponseEntity.status(200).body(dto);
-        }
-        else{
+        } else {
             log.info("유저 정보가 있다.");
-            String accessjwt =  jwtTokenProvider.createAccessToken(user.getUsername());
+            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK );
+            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
         }
- }
-
-
-
+    }
 }

--- a/src/main/java/com/dope/breaking/Security/UserInfoDto/InvalidAccessTokenResponse.java
+++ b/src/main/java/com/dope/breaking/Security/UserInfoDto/InvalidAccessTokenResponse.java
@@ -1,2 +1,17 @@
-package com.dope.breaking.Security.UserInfoDto;public class InvalidAccessTokenResponse {
+package com.dope.breaking.Security.UserInfoDto;
+
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+public class InvalidAccessTokenResponse {
+
+    private String AccessToken;
+
+    private String idToken; //구글 로그인 시 필요함.
+
+    private String ErrorMessage;
 }

--- a/src/main/java/com/dope/breaking/Security/UserInfoDto/InvalidAccessTokenResponse.java
+++ b/src/main/java/com/dope/breaking/Security/UserInfoDto/InvalidAccessTokenResponse.java
@@ -1,0 +1,2 @@
+package com.dope.breaking.Security.UserInfoDto;public class InvalidAccessTokenResponse {
+}

--- a/src/main/java/com/dope/breaking/Security/UserInfoDto/UserDto.java
+++ b/src/main/java/com/dope/breaking/Security/UserInfoDto/UserDto.java
@@ -16,4 +16,5 @@ public class UserDto {
 
     private String email;
 
+    private String profileImgURL;
 }

--- a/src/main/java/com/dope/breaking/repository/UserRepository.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepository.java
@@ -12,4 +12,6 @@ public interface UserRepository extends JpaRepository<User,Long> {
     Optional<User> findByPhoneNumber(String phoneNumber);
     Optional<User> findByEmail(String email);
 
+    Boolean existsByUsername(String username);
+
 }

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -5,6 +5,7 @@ import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -68,4 +69,11 @@ public class UserService {
         return userRepository.save(user);
 
     }
+
+
+    public Boolean existByUsername(String username){
+        return userRepository.existsByUsername(username);
+    }
+
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->

close #18

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
1. 엑세스 토큰 예외 처리가 추가되었습니다.  
 - 기존에는 유효하지 않는 토큰이 들어와도 어디서 에러가 표출되었는지 클라이언트가 알 방도가 없었습니다. 이에 에러 반환 객체를 만들어 406 status code와 함께 응답하도록 기능을 추가하였습니다.

2. 선택적 유저 정보 반환의 예외 처리가 추가되었습니다.
 - 선택적 유저 정보 추출에 있어 서비스 사용자가 원하지 않는 정보를 가져오려고 할시 에러가 표출되었습니다. 이에따라 없다면 Null을 반환하도록 수정하였습니다.

3. 유저 프로필 사진을 받는 필드를 추가하였습니다.

4. 마지막으로 UserRepository와 UserService에 existByUsername 메서드를 추가하였습니다. 기존에는 없다면 Null을 반환받아 if문에서 Null인지 판별하는 방식이였다면, Boolean값으로 바로 if 문에서 판별하도록 수정하였습니다. 

## 스크린샷
<img width="1514" alt="스크린샷 2022-06-30 오후 3 49 55" src="https://user-images.githubusercontent.com/62254434/176616713-f73366a3-24a4-447c-829c-d5762629f132.png">
<img width="1513" alt="스크린샷 2022-06-30 오후 3 51 48" src="https://user-images.githubusercontent.com/62254434/176616744-339a42dc-ba45-40b8-9a25-472702c0a1
<img width="1518" alt="스크린샷 2022-06-30 오후 3 52 58" src="https://user-images.githubusercontent.com/62254434/176616784-250c93f0-20df-49ed-b5f8-ca7661abab7f.png">
37.png">

 ## 기타
예외처리를 통해 발생할 추후의 충돌을 미연에 방지하고자 합니다. 이상입니다.
