### PR TITLE
feat: implement "responseMediaFile" method in MediaService

### DIFF
--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -6,10 +6,18 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -90,6 +98,20 @@ public class MediaService {
 
             mediaRepository.save(media);
         }
+
+    }
+
+    public ResponseEntity<FileSystemResource> responseMediaFile(String fileName) throws IOException {
+
+        String directory = dirName + "/" + fileName;
+
+        FileSystemResource fsr =  new FileSystemResource(directory);
+
+        HttpHeaders header = new HttpHeaders();
+        Path filePath = Paths.get(fileName);
+        header.add("Content-Type", Files.probeContentType(filePath));
+
+        return new ResponseEntity<FileSystemResource>(fsr, header, HttpStatus.OK);
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #22 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- MediaService에 "responseMediaFile" 메서드를 추가했습니다. 구체적인 기능은 아래와 같습니다:
  - 파라미터로 Media 엔티티에 들어가있는 파일경로를 받습니다.
  - FileSystemResponse 객체를 생성합니다.
  - ResponseEntity를 생성하고 Body에 FileSystemResponse를 주입합니다. 
  - ResponseEntity를 리턴합니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로남겨주세요. -->
아래와 같이 테스트를 해본 결과 잘 돌아갑니다. 
<img width="847" alt="스크린샷 2022-07-01 오후 12 47 11" src="https://user-images.githubusercontent.com/87322089/176822430-c68d0002-d227-49b4-a0ff-7e12f54aab08.png">

<img width="857" alt="스크린샷 2022-07-01 오후 12 51 13" src="https://user-images.githubusercontent.com/87322089/176822512-1d4eb26e-f0a8-47f2-bdac-eb273bf6968d.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
이게 큰 기능인 줄 알고 이슈를 따로 하나 생성했는데, 한 번의 PR에 쏘기에는 조금 적은 양이 아니었나 싶네요.
다음부터는 PR에 쏠 양 조절도 해봐야겠습니다.   