### PR TITLE
feat: add post create function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ out/
 
 ### VS Code ###
 .vscode/
+/src/main/resources/application-jwt.yml

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1'
 
 
+	implementation 'commons-io:commons-io:2.11.0'
+	implementation 'commons-fileupload:commons-fileupload:1.4'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dope/breaking/BreakingApplication.java
+++ b/src/main/java/com/dope/breaking/BreakingApplication.java
@@ -3,8 +3,10 @@ package com.dope.breaking;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
+@EnableJpaAuditing //JPA auditing 설정
 @SpringBootApplication
 public class BreakingApplication {
 

--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -1,20 +1,44 @@
 package com.dope.breaking.api;
 
+
+import com.dope.breaking.dto.post.PostCreateRequestDto;
+import com.dope.breaking.dto.post.PostResponse;
 import com.dope.breaking.dto.post.SearchFeedResponseDto;
+import com.dope.breaking.service.PostService;
 import com.dope.breaking.service.SearchFeedService;
 import com.dope.breaking.service.SortFilter;
+import com.dope.breaking.service.UserService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
+import java.security.Principal;
 import java.time.LocalDate;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-@RestController
+@Slf4j
 @RequiredArgsConstructor
+@RestController
 public class PostAPI {
 
     private final SearchFeedService searchFeedService;
+
+    private final UserService userService;
+
+    private final PostService postService;
+
 
     @GetMapping("/post/feed")
     public ResponseEntity<SearchFeedResponseDto> searchFeed(
@@ -39,6 +63,51 @@ public class PostAPI {
 
         return ResponseEntity.ok().body(new SearchFeedResponseDto());
 
+    }
+
+
+    @PreAuthorize("isAuthenticated()")//인증 되었는가? //403 Fobbiden 반환.
+    @PostMapping(value = "/post", consumes = {"multipart/form-data"})
+    public ResponseEntity<?> PostCreate(Principal principal,
+                                        @RequestPart(value = "mediaList") List<MultipartFile> files, @RequestPart(value = "data") @Valid PostCreateRequestDto postCreateRequestDto) {
+
+        log.info("여기까지 진입");
+        log.info("content : {}", postCreateRequestDto.toString());
+
+        Optional<String> cntusername = Optional.ofNullable(principal.getName());
+        Long postid;
+        if (cntusername.isEmpty()) {
+            PostResponse errorMsg = new PostResponse("현재 유저 정보가 없음");
+            return ResponseEntity.status(401).body(errorMsg);
+        }//유저 정보 없으면 일치하지 않다고 반환하기.
+        if (!userService.existByUsername(cntusername.get())) {
+            log.info("게시글 등록에 실패함");
+            PostResponse errorMsg = new PostResponse("등록되지 않은 유저");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMsg);
+        }
+        try {
+            postid = postService.create(cntusername.get(), postCreateRequestDto, files);
+            log.info("file info: {}", files.toString());
+
+        } catch (Exception e) {
+            log.info("게시글 등록에 실패함");
+            PostResponse errorMsg = new PostResponse("게시글 등록에 실패함");
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorMsg);
+        }
+        PostResponse postResponse = new PostResponse("등록된 게시글 번호: " + postid.toString());
+        return ResponseEntity.status(HttpStatus.OK).body(postResponse);
+    }
+
+
+    @ExceptionHandler(MethodArgumentNotValidException.class) //단일 컨트롤러에만 적용함.
+    public ResponseEntity<Map<String, String>> ValidationExceptions(MethodArgumentNotValidException e) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        List<ObjectError> errlist = e.getBindingResult().getAllErrors();
+        for (ObjectError err : errlist) {
+            FieldError fe = (FieldError) err;
+            errors.put(fe.getField(), fe.getDefaultMessage());
+        }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
     }
 
 }

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -2,6 +2,7 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.response.MessageResponseDto;
 import com.dope.breaking.dto.user.*;
 import com.dope.breaking.service.MediaService;
 import com.dope.breaking.service.UserService;

--- a/src/main/java/com/dope/breaking/domain/baseTimeEntity/BaseTimeEntity.java
+++ b/src/main/java/com/dope/breaking/domain/baseTimeEntity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.dope.breaking.domain.baseTimeEntity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass // 상속할 경우 필드들도 칼럼으로 인식하도록 한다.
+@EntityListeners(AuditingEntityListener.class) //EntityListener 등록
+public abstract class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false) //생성 시점부터 수정 불가로 만들어 주자
+    private LocalDateTime createdDate; //최초 생성 시간
+
+    @LastModifiedDate
+    private LocalDateTime modifiedDate; //마지막 수정 시간
+
+}

--- a/src/main/java/com/dope/breaking/domain/media/Media.java
+++ b/src/main/java/com/dope/breaking/domain/media/Media.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Getter
 public class Media {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name="MEDIA_ID")
     private Long id;
 

--- a/src/main/java/com/dope/breaking/domain/post/Location.java
+++ b/src/main/java/com/dope/breaking/domain/post/Location.java
@@ -1,8 +1,14 @@
 package com.dope.breaking.domain.post;
 
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
 import javax.persistence.Embeddable;
 
 @Embeddable
+@ToString
+@NoArgsConstructor
 public class Location {
 
     private String region;
@@ -10,5 +16,12 @@ public class Location {
     private Double longitude;
 
     private Double latitude;
+
+    @Builder
+    public Location(String region, Double longitude, Double latitude){
+        this.region = region;
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
 
 }

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -2,22 +2,28 @@ package com.dope.breaking.domain.post;
 
 
 
+import com.dope.breaking.domain.baseTimeEntity.BaseTimeEntity;
 import com.dope.breaking.domain.comment.Comment;
 import com.dope.breaking.domain.financial.Purchase;
 import com.dope.breaking.domain.media.Media;
 import com.dope.breaking.domain.user.User;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+@ToString
 @Entity
 @Getter
-public class Post {
+@NoArgsConstructor
+public class Post extends BaseTimeEntity {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column (name="POST_ID")
     private Long id;
 
@@ -56,5 +62,23 @@ public class Post {
     private boolean isHidden;
 
     private LocalDateTime eventTime;
+
+    @Builder
+    public Post(String title, String content, PostType postType, Location location, int price, boolean isAnonymous, LocalDateTime eventTime){
+        this.title = title;
+        this.content = content;
+        this.postType = postType;
+        this.location = location;
+        this.price = price;
+        this.isAnonymous = isAnonymous;
+        this.eventTime = eventTime;
+        this.isSold = false;
+        this.isHidden = false;
+    }
+
+    public void setUser(User user){
+        this.user = user;
+    }
+
 
 }

--- a/src/main/java/com/dope/breaking/domain/post/PostType.java
+++ b/src/main/java/com/dope/breaking/domain/post/PostType.java
@@ -1,5 +1,14 @@
 package com.dope.breaking.domain.post;
 
+import lombok.*;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
 public enum PostType {
-    EXCLUSIVE, CHARGED, FREE;
+    EXCLUSIVE("exclusive"),
+    CHARGED("charged"),
+    FREE("free");
+
+    private final String title;
 }

--- a/src/main/java/com/dope/breaking/dto/post/LocationDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/LocationDto.java
@@ -1,0 +1,28 @@
+package com.dope.breaking.dto.post;
+
+import com.dope.breaking.domain.post.Location;
+import com.fasterxml.jackson.annotation.JsonRootName;
+import lombok.*;
+
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@Setter
+@Getter
+@ToString
+@JsonRootName(value = "location")
+public class LocationDto {
+    @NotNull
+    private String region;
+    @NotNull
+    private Double longitude;
+    @NotNull
+    private Double latitude;
+
+    @Builder
+    public LocationDto(String region, Double longitude, Double latitude){
+        this.region = region;
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
+}

--- a/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
@@ -1,0 +1,41 @@
+package com.dope.breaking.dto.post;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@ToString
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PostCreateRequestDto {
+    @NotNull
+    private String title;
+    @NotNull
+    private String content;
+
+    private int price;
+    @NotNull
+    private Boolean isAnonymous;
+    @NotNull
+    private String postType;
+
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.SCALAR, pattern = "yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime eventTime;
+
+
+    @JsonProperty("location") //locationDto에 location이라는 이름으로 된, key값을 받음.
+    @Valid
+    private LocationDto locationDto;
+
+
+    private List<String> hashtagList;
+}

--- a/src/main/java/com/dope/breaking/dto/post/PostResType.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostResType.java
@@ -1,0 +1,21 @@
+package com.dope.breaking.dto.post;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum PostErrorType {
+
+    NOT_FOUND_USER("not found user"),
+    NOT_REGISTERED_USER("not registered user"),
+    POST_FAILED("posting failed");
+
+
+    private final String message;
+
+
+    public String getMessage() {
+
+        return this.message;
+
+    }
+}

--- a/src/main/java/com/dope/breaking/dto/post/PostResType.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostResType.java
@@ -3,11 +3,12 @@ package com.dope.breaking.dto.post;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public enum PostErrorType {
+public enum PostResType {
 
     NOT_FOUND_USER("not found user"),
     NOT_REGISTERED_USER("not registered user"),
     POST_FAILED("posting failed");
+
 
 
     private final String message;

--- a/src/main/java/com/dope/breaking/dto/post/PostResponse.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostResponse.java
@@ -1,0 +1,17 @@
+package com.dope.breaking.dto.post;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Setter
+@Getter
+public class PostResponse {
+
+    private String Msg;
+
+}

--- a/src/main/java/com/dope/breaking/dto/response/MessageResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/response/MessageResponseDto.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.dto.user;
+package com.dope.breaking.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.Security.config;
+package com.dope.breaking.security.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityconfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityconfig.java
@@ -1,11 +1,10 @@
-package com.dope.breaking.Security.config;
+package com.dope.breaking.security.config;
 
-import com.dope.breaking.Security.Handler.JwtExceptHandler;
-import com.dope.breaking.Security.Jwt.JwtAuthenticationFilter;
-import com.dope.breaking.Security.Jwt.JwtEntryPoint;
-import com.dope.breaking.Security.Jwt.JwtTokenProvider;
-import com.dope.breaking.Security.UserDetails.PrincipalDetailsService;
-import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.security.handler.JwtExceptHandler;
+import com.dope.breaking.security.jwt.JwtAuthenticationFilter;
+import com.dope.breaking.security.jwt.JwtEntryPoint;
+import com.dope.breaking.security.jwt.JwtTokenProvider;
+import com.dope.breaking.security.userDetails.PrincipalDetailsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -37,13 +36,13 @@ public class WebSecurityconfig extends WebSecurityConfigurerAdapter {
     private final PasswordEncoder passwordEncoder;
 
 
-    @Bean
-    public AuthenticationManager authenticationManager() {//AuthenticationManager 등록
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();//Form 형식의 DaoAuthenticationProvider 사용 -> 여기서 아이디와 password를 대조하여 비교함.
-        provider.setPasswordEncoder(passwordEncoder);//PasswordEncoder로는 BCry를 사용할 것임.
-        provider.setUserDetailsService(principalDetailsService); //UserDtailsService는 예전에 작성한 것으로. 유저 인증절차는 이친구에게 넘김.
-        return new ProviderManager(provider);
-    }
+//    @Bean
+//    public AuthenticationManager authenticationManager() {//AuthenticationManager 등록
+//        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();//Form 형식의 DaoAuthenticationProvider 사용 -> 여기서 아이디와 password를 대조하여 비교함.
+//        provider.setPasswordEncoder(passwordEncoder);//PasswordEncoder로는 BCry를 사용할 것임.
+//        provider.setUserDetailsService(principalDetailsService); //UserDtailsService는 예전에 작성한 것으로. 유저 인증절차는 이친구에게 넘김.
+//        return new ProviderManager(provider);
+//    }
 
 
     @Override

--- a/src/main/java/com/dope/breaking/security/controller/Oauth2LoginController.java
+++ b/src/main/java/com/dope/breaking/security/controller/Oauth2LoginController.java
@@ -1,10 +1,9 @@
-package com.dope.breaking.Security.SecurityController;
+package com.dope.breaking.security.controller;
 
 
-import ch.qos.logback.core.encoder.EchoEncoder;
-import com.dope.breaking.Security.Jwt.JwtTokenProvider;
-import com.dope.breaking.Security.UserInfoDto.InvalidAccessTokenResponse;
-import com.dope.breaking.Security.UserInfoDto.UserDto;
+import com.dope.breaking.security.jwt.JwtTokenProvider;
+import com.dope.breaking.security.userInfoDto.InvalidAccessTokenResponse;
+import com.dope.breaking.security.userInfoDto.UserDto;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,7 +14,6 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Map;

--- a/src/main/java/com/dope/breaking/security/handler/JwtExceptHandler.java
+++ b/src/main/java/com/dope/breaking/security/handler/JwtExceptHandler.java
@@ -1,9 +1,7 @@
-package com.dope.breaking.Security.Handler;
+package com.dope.breaking.security.handler;
 
 import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;

--- a/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
@@ -1,6 +1,6 @@
-package com.dope.breaking.Security.Jwt;
+package com.dope.breaking.security.jwt;
 
-import com.dope.breaking.Security.UserDetails.PrincipalDetailsService;
+import com.dope.breaking.security.userDetails.PrincipalDetailsService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;

--- a/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.Security.Jwt;
+package com.dope.breaking.security.jwt;
 
 import org.json.simple.JSONObject;
 import org.springframework.security.core.AuthenticationException;

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -1,20 +1,14 @@
-package com.dope.breaking.Security.Jwt;
+package com.dope.breaking.security.jwt;
 
-import com.dope.breaking.Security.UserDetails.PrincipalDetailsService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.*;
 

--- a/src/main/java/com/dope/breaking/security/userDetails/PrincipalDetails.java
+++ b/src/main/java/com/dope/breaking/security/userDetails/PrincipalDetails.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.Security.UserDetails;
+package com.dope.breaking.security.userDetails;
 
 import com.dope.breaking.domain.user.User;
 import org.springframework.security.core.GrantedAuthority;
@@ -6,7 +6,6 @@ import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
 
 public class PrincipalDetails implements UserDetails {
 

--- a/src/main/java/com/dope/breaking/security/userDetails/PrincipalDetailsService.java
+++ b/src/main/java/com/dope/breaking/security/userDetails/PrincipalDetailsService.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.Security.UserDetails;
+package com.dope.breaking.security.userDetails;
 
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.repository.UserRepository;

--- a/src/main/java/com/dope/breaking/security/userInfoDto/InvalidAccessTokenResponse.java
+++ b/src/main/java/com/dope/breaking/security/userInfoDto/InvalidAccessTokenResponse.java
@@ -1,9 +1,8 @@
-package com.dope.breaking.Security.UserInfoDto;
+package com.dope.breaking.security.userInfoDto;
 
 
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 
 @Getter
 @Setter

--- a/src/main/java/com/dope/breaking/security/userInfoDto/UserDto.java
+++ b/src/main/java/com/dope/breaking/security/userInfoDto/UserDto.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.Security.UserInfoDto;
+package com.dope.breaking.security.userInfoDto;
 
 
 import lombok.*;

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
@@ -31,8 +32,10 @@ public class MediaService {
     private final MediaRepository mediaRepository;
 
     //디렉토리는 추후 AWS내의 디렉토리로 변경
-    private final String dirName = "/Users/gimmin-u/Desktop/testImgFolder";
+    //private final String dirName = "/Users/gimmin-u/Desktop/testImgFolder";
 
+    //Martin0o0 dir
+    private final  String dirName = System.getProperty("user.dir") + "/files";
     public List<String> uploadMedias(List<MultipartFile> medias) throws Exception{
 
         List<String> fileNameList = new ArrayList<String>();
@@ -88,6 +91,7 @@ public class MediaService {
 
     }
 
+    @Transactional //혹여나, 실패 시 자동 롤백 하기 위해.
     public void createMediaEntities(List<String> fileNameList, Post post){
 
         for (String fileName : fileNameList) {

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -1,0 +1,85 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.post.Location;
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostType;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.post.PostCreateRequestDto;
+import com.dope.breaking.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class PostService {
+    private final PostRepository postRepository;
+
+    private final UserService userService;
+
+    private final MediaService mediaService;
+
+
+    @Transactional
+    public Long create(String username, PostCreateRequestDto postCreateRequestDto, List<MultipartFile> files) {
+        Long postid = null; // null로 초기
+
+        PostType postType = null;
+        if (PostType.EXCLUSIVE.getTitle().equals(postCreateRequestDto.getPostType())) {
+            postType = PostType.EXCLUSIVE;
+        } else if (PostType.CHARGED.getTitle().equals(postCreateRequestDto.getPostType())) {
+            postType = PostType.CHARGED;
+        } else if (PostType.FREE.getTitle().equals(postCreateRequestDto.getPostType())) {
+            postType = PostType.FREE;
+        }
+        Post post = new Post();
+        try {
+            post = Post.builder()
+                    .title(postCreateRequestDto.getTitle())
+                    .content(postCreateRequestDto.getContent())
+                    .postType(postType)
+                    .location(Location.builder()
+                            .region(postCreateRequestDto.getLocationDto().getRegion())
+                            .latitude(postCreateRequestDto.getLocationDto().getLatitude())
+                            .longitude(postCreateRequestDto.getLocationDto().getLongitude()).build())
+                    .eventTime(postCreateRequestDto.getEventTime())
+                    .isAnonymous(postCreateRequestDto.getIsAnonymous())
+                    .price(postCreateRequestDto.getPrice())
+                    .build();
+            log.info("content info : {} ", post.toString());
+            if (post.isAnonymous()) {//익명성이라면, 유저 정보는 존재하지 않는다.
+                post.setUser(null);
+            } else {
+                User user = userService.findByUsername(username).get();
+                post.setUser(user);
+            }
+            postid = postRepository.save(post).getId();
+        } catch (Exception e) {
+            log.info("게시글 entity화 실패.");
+            throw e;
+        }
+
+        List<String> filename = new LinkedList<>();
+        if (!files.isEmpty() && files.get(0).getSize() != 0) {//사용자가 파일을 보내지 않아도 기본적으로 갯수는 1로 반영되며, byte는 0으로 반환된다. 따라서 파일이 확실히 존재할때만 DB에 반영되도록 함.
+            try {
+                filename = mediaService.uploadMedias(files);
+
+            } catch (Exception e) {
+                log.info("파일이 정상적으로 처리되지 않음");
+                log.info(e.toString());
+            }
+            mediaService.createMediaEntities(filename, post);
+        }
+
+
+        return postid;
+    }
+
+
+}

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -52,13 +52,8 @@ public class PostService {
                     .isAnonymous(postCreateRequestDto.getIsAnonymous())
                     .price(postCreateRequestDto.getPrice())
                     .build();
-            log.info("content info : {} ", post.toString());
-            if (post.isAnonymous()) {//익명성이라면, 유저 정보는 존재하지 않는다.
-                post.setUser(null);
-            } else {
-                User user = userService.findByUsername(username).get();
-                post.setUser(user);
-            }
+            User user = userService.findByUsername(username).get();
+            post.setUser(user);
             postid = postRepository.save(post).getId();
         } catch (Exception e) {
             log.info("게시글 entity화 실패.");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:tcp://localhost/~/jpashop
+    url: jdbc:h2:~/local
     username: sa
     password:
     driver-class-name: org.h2.Driver
@@ -14,6 +14,16 @@ spring:
         format_sql: true
   profiles:
     include: jwt
+  h2:
+    console:
+      enabled: true
+      path: /console
+
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 20MB
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #24 

## 예상 리뷰 시간
40-min

## 추가 또는 변경사항
1. 우선, MultiPart의 최대 파일 용량을 10MB으로 임시로 제한하였습니다. 또한, 서버에 최대로 보낼 수 있는 요청 크기는 20MB로 임시로 제한하였습니다. 이를 무시할 시 기본값으로 설정된 파일 최대 용량 1MB만 수용하기에 임시로 제한을 걸어두었습니다. 

2. git ignore에 Jwt secretcode가 담긴 yml파일을 추가하였습니다. 

3. Post, Media Entity의 @GenerateValue 전략을 구체화 하였습니다. 
  테스트를 진행하며, 처음 저장하는 엔티티 임에도 불구하고 pk 값이 2로 시작하여 전략을 구체화 시켜주니 1로 시작하였습니다. 

4. PostType Enum의 title을 지정해주어, 요청 받을 시 String값에 따라 Type을 지정할 수 있도록 하였습니다. 

5. 최초 생성시간, 최종 수정 시간을 기록하는 EntityListener를 추가하였습니다.

6. 게시글을 등록하는 기능을 구현하였습니다. validation을 접목하였고, ExceptionHandler를 바탕으로 예외처리를 구현하였습니다. 시큐리티의 어노테이션인 @PreAuthorize를 통해 해당 유저가 로그인 되어있는 상태에서의 요청인지를 우선 확인 하며, Principal 객체을 바탕으로 현재 글쓴이의 username을 가져옵니다. 

7. 마지막으로 Security 파일명을 수정하였습니다. 통일성있게 LowerCase로 변경하였습니다.

## 스크린샷
1. 필드에 값이 비어있다면, 예외처리를 통해 문제가 있는 필드를 표시합니다. 
<img width="1492" alt="스크린샷 2022-07-04 오후 12 31 34" src="https://user-images.githubusercontent.com/62254434/177081684-f377d993-cddc-4a83-81c0-920b4da0014b.png">

2. postMan으로 테스트해본 결과, 시큐리티 컨텍스트에 저장된 현재 유저 정보를 기반으로 게시글을 저장합니다.
<img width="1495" alt="스크린샷 2022-07-04 오후 12 30 09" src="https://user-images.githubusercontent.com/62254434/177082094-b870241a-68c0-4111-bf11-d812cca2eb3f.png">

5. H2 DB에도 저장한 정보들이 잘 저장 되었습니다.
<img width="1284" alt="스크린샷 2022-07-04 오후 12 32 06" src="https://user-images.githubusercontent.com/62254434/177082155-47575812-9c1e-4799-94ec-04d4df0c55ca.png">

<img width="491" alt="스크린샷 2022-07-04 오후 12 32 15" src="https://user-images.githubusercontent.com/62254434/177082174-e99b7199-e187-4760-b420-0204724df99d.png">



## 기타
맛동산 님이 기존에 구현해 놓으신 File Handler 부분을 토대로 코드를 작성하였기 때문에, 수월하게 기능 구현을 수 있었습니다. 덕분에 예외처리부분에 신경써서 코드를 작성 할 수 있었습니다. 
