### PR TITLE
feat: add 403 status code in entrypoint

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -74,10 +74,10 @@ public class PostAPI {
         Optional<String> cntusername = Optional.ofNullable(principal.getName());
         Long postid;
         if (cntusername.isEmpty()) {
-            return ResponseEntity.status(401).body(new MessageResponseDto(PostResType.NOT_FOUND_USER.getMessage()));
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new MessageResponseDto(PostResType.NOT_FOUND_USER.getMessage()));
         }//유저 정보 없으면 일치하지 않다고 반환하기.
         if (!userService.existByUsername(cntusername.get())) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new MessageResponseDto(PostResType.NOT_REGISTERED_USER.getMessage()));
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new MessageResponseDto(PostResType.NOT_REGISTERED_USER.getMessage()));
         }
         try {
             postid = postService.create(cntusername.get(), postCreateRequestDto, files);

--- a/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
@@ -52,16 +52,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//모든 서�
         else if(accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == false){
             try {
                 String username = jwtTokenProvider.getUsername(accesstoken); //해독 과정 중 에러가 발생함.
-            } catch (SecurityException | MalformedJwtException e) {
-                request.setAttribute("exception", "인증이 유효하지 않음");
+            } catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
+                request.setAttribute("exception", "Invalid Signature");
             } catch (ExpiredJwtException e) {
-                request.setAttribute("exception", "만료됨");
-            } catch (UnsupportedJwtException e) {
-                request.setAttribute("exception", "jwt에서 지원하지 않음");
-            } catch (IllegalArgumentException e) {
-                request.setAttribute("exception", "유효하지 않는 토큰");
+                request.setAttribute("exception", "Expiration date");
             } catch (Exception e) {
-                request.setAttribute("exception", "기타 오류");
+                request.setAttribute("exception", "Other errors related to jwt");
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
@@ -18,6 +18,13 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
 
         if (exception != null) {
             setResponse(response, exception);
+        }else{
+            JSONObject responseJson = new JSONObject();
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            responseJson.put("message", "jwt token is required");
+
+            response.getWriter().print(responseJson);
         }
     }
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -58,7 +58,7 @@ public class JwtTokenProvider {
         try {
             Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
             return true;
-        } catch (SignatureException e) {
+        }  catch (SignatureException  | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
@@ -66,6 +66,8 @@ public class JwtTokenProvider {
             log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
             log.info("JWT 토큰이 잘못되었습니다.");
+        }catch(Exception e){
+            log.info("JWT에 알 수 없는 문제가 발생하였습니다");
         }
         return false;
     }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #33 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
기존에 PreAuthorize어노테이션 적용 후 jwt 토큰 없이 요청하여도 200ok가 반환되었지만, 이번 기능 추가를 통해 403 Forbidden이 정상적으로 응답합니다.

마지막으로, Jwt과 관련해서 필수적인 예외들을 간추려서 응답하도록 수정하였습니다.

## 스크린샷
<img width="1205" alt="스크린샷 2022-07-05 오전 10 25 39" src="https://user-images.githubusercontent.com/62254434/177232419-202069b1-c4c3-4677-8fb0-be607e857d69.png">
<img width="1209" alt="스크린샷 2022-07-05 오전 10 25 54" src="https://user-images.githubusercontent.com/62254434/177232428-9385e3ef-1b81-44e3-b476-22a8c3d93731.png">
<img width="1205" alt="스크린샷 2022-07-05 오전 10 26 06" src="https://user-images.githubusercontent.com/62254434/177232445-55e6ad84-4eab-492f-98a0-72d141524306.png">


## 기타
 없음.