### PR TITLE
feat : add thumbnail image creation function

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,11 @@ dependencies {
 	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
     implementation 'commons-fileupload:commons-fileupload:1.4'
 	implementation 'commons-io:commons-io:2.11.0'
+
+	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.11'
+	implementation group: 'org.jcodec', name: 'jcodec', version: '0.2.3'
+	implementation group: 'org.jcodec', name: 'jcodec-javase', version: '0.2.3'
+
 }
 
 
@@ -62,6 +67,7 @@ configurations {
 		extendsFrom annotationProcessor
 	}
 	querydsl.extendsFrom compileClasspath
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -57,21 +57,20 @@ public class PostAPI {
     }
 
 
-    @PreAuthorize("isAuthenticated()")//인증 되었는가? //403 Forbidden 반환.
-    @PostMapping(value = "/post", consumes = {"multipart/form-data"})
+    @PreAuthorize("isAuthenticated()")//인증 되었는가? //403 Fobbiden 반환.
+    @PostMapping(value = "/post")
     public ResponseEntity<?> PostCreate(Principal principal,
-                                        @RequestPart(value = "mediaList") List<MultipartFile> files, @RequestPart(value = "data") @Valid PostCreateRequestDto postCreateRequestDto) {
-
-        Optional<String> cntusername = Optional.ofNullable(principal.getName());
+                                        @RequestPart(value = "mediaList", required = false) List<MultipartFile> files, @RequestPart(value = "data") @Valid PostCreateRequestDto postCreateRequestDto) {
         Long postid;
-        if (cntusername.isEmpty()) {
+        if (principal ==  null) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).body(new MessageResponseDto(PostResType.NOT_FOUND_USER.getMessage()));
         }//유저 정보 없으면 일치하지 않다고 반환하기.
-        if (!userService.existByUsername(cntusername.get())) {
+        String cntusername = principal.getName();
+        if (!userService.existByUsername(cntusername)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new MessageResponseDto(PostResType.NOT_REGISTERED_USER.getMessage()));
         }
         try {
-            postid = postService.create(cntusername.get(), postCreateRequestDto, files);
+            postid = postService.create(cntusername, postCreateRequestDto, files);
 
         } catch (Exception e) {
             log.info("게시글 등록에 실패함");
@@ -81,6 +80,7 @@ public class PostAPI {
         result.put("postId", postid);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
+
 
 
     @ExceptionHandler(MethodArgumentNotValidException.class) //단일 컨트롤러에만 적용함.

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -88,4 +88,8 @@ public class Post extends BaseTimeEntity {
         this.user = user;
     }
 
+    public void setThumbnailImgURL(String thumbnailURL){
+        this.thumbnailImgURL = thumbnailURL;
+    }
+
 }

--- a/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
@@ -38,4 +38,6 @@ public class PostCreateRequestDto {
 
 
     private List<String> hashtagList;
+
+    private int thumbnailIndex;
 }

--- a/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostCreateRequestDto.java
@@ -28,7 +28,7 @@ public class PostCreateRequestDto {
 
     @NotNull
     @JsonFormat(shape = JsonFormat.Shape.SCALAR, pattern = "yyyy-MM-dd HH:mm:ss")
-    @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime eventTime;
 
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//모든 서�
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
         String accesstoken = jwtTokenProvider.extractAccessToken(request).orElse(null); //accesstoken으로 받아졌는지 확인
-        log.info("access token : {}", accesstoken);
 
         //엑세스 토큰은 null이 아니고 엑세스 토큰이 유효하다면
         if (accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == true) {

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -6,23 +6,29 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.repository.MediaRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnailator;
+import org.jcodec.api.FrameGrab;
+import org.jcodec.common.model.Picture;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
+import org.jcodec.scale.AWTUtil;
 
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.*;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @Slf4j
@@ -42,38 +48,42 @@ public class MediaService {
         return basicProfileDir;
     }
 
-    public String getDirName(){return dirName;}
+    public String getDirName() {
+        return dirName;
+    }
 
-    public List<String> uploadMedias(List<MultipartFile> medias) throws Exception{
+    private final String thumName = System.getProperty("user.dir") + "/thum";
+
+    public List<String> uploadMedias(List<MultipartFile> medias) throws Exception {
 
         List<String> fileNameList = new ArrayList<String>();
 
-        try{
+        try {
 
-            File folder =  new File(dirName);
+            File folder = new File(dirName);
 
-            if (!folder.exists()){
+            if (!folder.exists()) {
                 folder.mkdirs();
             }
 
-            for (MultipartFile media : medias){
+            for (MultipartFile media : medias) {
 
                 String fileName = media.getOriginalFilename();
                 String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-                String generatedFileName = UUID.randomUUID().toString()+"."+extension;
+                String generatedFileName = UUID.randomUUID().toString() + "." + extension;
 
                 fileNameList.add(generatedFileName);
 
-                File destination =  new File(dirName + File.separator + generatedFileName);
+                File destination = new File(dirName + File.separator + generatedFileName);
                 media.transferTo(destination);
 
             }
 
-        }catch(Exception e){
+        } catch (Exception e) {
 
-            log.error("error: "+e.getMessage());
+            log.error("error: " + e.getMessage());
 
-        }finally{
+        } finally {
 
             return fileNameList;
 
@@ -81,17 +91,83 @@ public class MediaService {
 
     }
 
-    public MediaType findMediaType (String fileName){
+
+    public Map<String, List<String>> uploadMediaAndThumbnail(List<MultipartFile> thumbnail, int index) throws Exception {
+
+        Map<String, List<String>> mediaList = new LinkedHashMap<>();
+
+        try {
+
+            File folder = new File(dirName);
+
+            if (!folder.exists()) {
+                folder.mkdirs();
+            }
+            List<String> list = new LinkedList<>();
+            for (int i = 0; i < thumbnail.size(); i++) {
+
+                String fileName = thumbnail.get(i).getOriginalFilename();
+                String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
+                String generatedFileName = UUID.randomUUID().toString() + "." + extension;
+
+                list.add(generatedFileName);
+
+                File destination = new File(dirName + File.separator + generatedFileName);
+                thumbnail.get(i).transferTo(destination);
+                log.info(Long.toString(index));
+                if (index == i) {
+                    File thumfolder = new File(thumName);
+
+                    if (!thumfolder.exists()) {
+                        thumfolder.mkdirs();
+                    }
+                    String generatedThumFileName = "s_" + UUID.randomUUID().toString() + "." + extension;
+                    List<String> videoExtension = Arrays.asList("mp4", "mov", "mpg", "mpeg", "gif", "rm", "vob");
+                    if (!videoExtension.contains(extension)) {
+                        File thumdestination = new File(thumName + File.separator + generatedThumFileName);
+                        mediaList.put("thumbnail", List.of(generatedThumFileName));
+                        Thumbnailator.createThumbnail(destination, thumdestination, 500, 500);
+                    } else {
+                        Picture frame = FrameGrab.getFrameFromFile(destination, 0);
+                        BufferedImage img = AWTUtil.toBufferedImage(frame);
+                        img = AWTUtil.rotate90ToLeft(img);
+                        generatedThumFileName = "s_" + UUID.randomUUID().toString() + ".png";
+                        mediaList.put("thumbnail", Arrays.asList(generatedThumFileName));
+                        File thumdestination = new File(thumName + File.separator + generatedThumFileName);
+                        ImageIO.write(img, "png", thumdestination);
+                        Thumbnailator.createThumbnail(thumdestination, thumdestination, 500, 500);
+                    }
+                }
+
+
+            }
+            mediaList.put("mediaList", list);
+
+        } catch (Exception e) {
+
+            log.error("error: " + e.getMessage());
+
+        } finally {
+
+
+            return mediaList;
+
+        }
+
+
+    }
+
+
+    public MediaType findMediaType(String fileName) {
 
         String extension = fileName.substring(fileName.lastIndexOf(".") + 1);
-        List<String> videoExtension = Arrays.asList("mp4","mov","mpg","mpeg","gif","rm","vob");
+        List<String> videoExtension = Arrays.asList("mp4", "mov", "mpg", "mpeg", "gif", "rm", "vob");
 
-        if(videoExtension.contains(extension)){
+        if (videoExtension.contains(extension)) {
 
             return MediaType.VIDEO;
 
-        }
-        else{
+        } else {
 
             return MediaType.PHOTO;
 
@@ -100,13 +176,13 @@ public class MediaService {
     }
 
     @Transactional //혹여나, 실패 시 자동 롤백 하기 위해.
-    public void createMediaEntities(List<String> fileNameList, Post post){
+    public void createMediaEntities(List<String> fileNameList, Post post) {
 
         for (String fileName : fileNameList) {
 
             MediaType mediaType = findMediaType(fileName);
 
-            Media media = new Media(post,mediaType,fileName);
+            Media media = new Media(post, mediaType, fileName);
 
             mediaRepository.save(media);
         }
@@ -117,7 +193,7 @@ public class MediaService {
 
         String directory = dirName + "/" + fileName;
 
-        FileSystemResource fsr =  new FileSystemResource(directory);
+        FileSystemResource fsr = new FileSystemResource(directory);
 
         HttpHeaders header = new HttpHeaders();
         Path filePath = Paths.get(fileName);

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -8,8 +8,6 @@ import com.dope.breaking.dto.post.PostCreateRequestDto;
 import com.dope.breaking.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -62,7 +60,6 @@ public class PostService {
         }
 
         Map<String, List<String>> map = new LinkedHashMap<>();
-        String thumbnailname = new String();
         if (!files.isEmpty() && files.get(0).getSize() != 0) {//사용자가 파일을 보내지 않아도 기본적으로 갯수는 1로 반영되며, byte는 0으로 반환된다. 따라서 파일이 확실히 존재할때만 DB에 반영되도록 함.
             try {
                 map = mediaService.uploadMediaAndThumbnail(files, postCreateRequestDto.getThumbnailIndex());

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -8,12 +8,13 @@ import com.dope.breaking.dto.post.PostCreateRequestDto;
 import com.dope.breaking.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,8 +28,8 @@ public class PostService {
 
 
     @Transactional
-    public Long create(String username, PostCreateRequestDto postCreateRequestDto, List<MultipartFile> files) {
-        Long postid = null; // null로 초기
+    public Long create(String username, PostCreateRequestDto postCreateRequestDto, List<MultipartFile> files) throws Exception {
+        Long postid = null; // null로 초기화
 
         PostType postType = null;
         if (PostType.EXCLUSIVE.getTitle().equals(postCreateRequestDto.getPostType())) {
@@ -60,16 +61,21 @@ public class PostService {
             throw e;
         }
 
-        List<String> filename = new LinkedList<>();
+        Map<String, List<String>> map = new LinkedHashMap<>();
+        String thumbnailname = new String();
         if (!files.isEmpty() && files.get(0).getSize() != 0) {//사용자가 파일을 보내지 않아도 기본적으로 갯수는 1로 반영되며, byte는 0으로 반환된다. 따라서 파일이 확실히 존재할때만 DB에 반영되도록 함.
             try {
-                filename = mediaService.uploadMedias(files);
+                map = mediaService.uploadMediaAndThumbnail(files, postCreateRequestDto.getThumbnailIndex());
+                log.info(files.get(postCreateRequestDto.getThumbnailIndex()).getOriginalFilename());
 
             } catch (Exception e) {
                 log.info("파일이 정상적으로 처리되지 않음");
                 log.info(e.toString());
+                throw e;
             }
-            mediaService.createMediaEntities(filename, post);
+            log.info(map.get("mediaList").toString());
+            mediaService.createMediaEntities(map.get("mediaList"), post);
+            post.setThumbnailImgURL(map.get("thumbnail").get(0).toString());
         }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,8 +22,8 @@ spring:
 
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 20MB
+      max-file-size: 100MB
+      max-request-size: 200MB
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #31 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
1. 유저가 지정한 사진 혹은 동영상(인덱스)에 썸네일 사진을 생성하는 기능을 추가하였습니다.
 기존 MediaService단에서 썸네일만 생성하는 메서드를 만들려고 하였으나, 톰캣 내부의 알 수 없는 오류로 인하여 인덱스와 파일을 같이 받아 생성하는 쪽으로 방향을 바꾸었습니다. 

2. 파일 최대 용량을 임시로 100MB까지 올렸습니다.
  대다수의 영상이 50MB를 넘기에 임시로 올렸습니다.

3. Thumbnailor 라이브러리와 Jcodec 라이브러리의 dependency를 축가하였습니다.
  두 라이브러리를 통해 사진 및 동영상의 썸네일 생성을 구현하였습니다.

4. 썸네일은 최대 너비 500, 높이 500으로 맞추었습니다. 
  height와 width가 동일하면 사진이 왜곡되기에, 최대 크기에 맞게 다운스케일링 하도록 구현하였습니다.

5. Optional<Principal> 구문을 삭제하여습니다. null Exception을 잡으려 Opional을 사용하였지만, 되려 에러가 발생하는 문제가 생겨 if(principal == null)로 대체하였습니다. 

## 스크린샷
<img width="722" alt="스크린샷 2022-07-05 오후 4 40 21" src="https://user-images.githubusercontent.com/62254434/177316851-0880fa2d-0043-401a-8418-3299f2b0c36b.png">
<img width="1582" alt="스크린샷 2022-07-05 오후 4 43 32" src="https://user-images.githubusercontent.com/62254434/177316920-3019abad-ea4c-421d-bdb4-31e0026ddb62.png">
<img width="1102" alt="스크린샷 2022-07-05 오후 8 09 28" src="https://user-images.githubusercontent.com/62254434/177316990-b970fbab-b97e-4a9a-91d3-c73b55ecf92d.png">
![s_49e69562-bc31-43d7-9e1b-2e3fe54eb4d1](https://user-images.githubusercontent.com/62254434/177317140-8cb0d1fa-b2cb-41b8-a294-c503cba0f928.JPG)



## 기타
현재 동영상 썸네일 제작하는 부분에서 시간이 너무 지체되어서, 나중으로 미루고 수정단계 돌입하도록 하겠습니다. 우선, 가로 영상의 경우세로로 썸네일이 생성됩니다. 추후 수정하도록 하겠습니다. 불필요한 로그를 삭제하였습니다. 또한, 파일 저장 시 영상은 mp4로 저장하도록 수정하였습니다.
