### PR TITLE
feat: implement Api logics for UpdateUser & implement default profile image when user never selects it.

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -65,7 +65,7 @@ public class PostAPI {
     }
 
 
-    @PreAuthorize("isAuthenticated()")//인증 되었는가? //403 Fobbiden 반환.
+    @PreAuthorize("isAuthenticated()")//인증 되었는가? //403 Forbidden 반환.
     @PostMapping(value = "/post", consumes = {"multipart/form-data"})
     public ResponseEntity<?> PostCreate(Principal principal,
                                         @RequestPart(value = "mediaList") List<MultipartFile> files, @RequestPart(value = "data") @Valid PostCreateRequestDto postCreateRequestDto) {

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -76,26 +77,18 @@ public class UserAPI {
 
     }
 
-//    @PutMapping("/profile/{userId}",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-//    public void updateProfile(
-//            @PathVariable(value = "userId") String userId,
-//            @RequestPart @Valid SignUpRequestDto signUpRequestDto,
-//            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception{
-//
-//
-//
-//    }
+  
 
-    @PostMapping(value = "/oauth2/sign-up",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<MessageResponseDto> signInConfirm(
             @RequestPart @Valid SignUpRequestDto signUpRequest,
             @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
-        
-        String invalidateMessage = userService.invalidMessage(signUpRequest);
 
-        if (invalidateMessage != ""){
+        String invalidMessage = userService.invalidMessage(signUpRequest);
+
+        if (invalidMessage != ""){
             return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(invalidateMessage));
+                    .body(new MessageResponseDto(invalidMessage));
         }
 
         String profileImgFileName = mediaService.getBasicProfileDir();
@@ -104,15 +97,12 @@ public class UserAPI {
             profileImgFileName =  mediaService.uploadMedias(profileImg).get(0);
         }
 
-        User user = new User();
-
-        user.signUp(
+        User user = new User(
                 profileImgFileName,
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
-                signUpRequest.getFirstName(),
-                signUpRequest.getLastName(),
+                signUpRequest.getRealName(),
                 signUpRequest.getStatusMsg(),
                 signUpRequest.getUsername(),
                 Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -82,7 +82,7 @@ public class UserAPI {
     @PostMapping(value = "/oauth2/sign-up",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<MessageResponseDto> signInConfirm(
             @RequestPart @Valid SignUpRequestDto signUpRequest,
-            @RequestPart List<MultipartFile> profileImg) throws Exception {
+            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
 
         if(!userService.isValidRole(signUpRequest.getRole())){
             return ResponseEntity.badRequest()
@@ -114,12 +114,16 @@ public class UserAPI {
                     .body(new MessageResponseDto(SignUpErrorType.NICKNAME_DUPLICATE.getMessage()));
         }
 
-        List<String> generatedFileNameList = mediaService.uploadMedias(profileImg);
+        String profileImgFileName = mediaService.getBasicProfileDir();
+
+        if (profileImg != null){
+            profileImgFileName =  mediaService.uploadMedias(profileImg).get(0);
+        }
 
         User user = new User();
 
         user.signUp(
-                generatedFileNameList.get(0),
+                profileImgFileName,
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -106,8 +106,6 @@ public class UserAPI {
             return ResponseEntity.badRequest().body(nullFieldMap);
         }
 
-        System.out.println("=========");
-
         String invalidMessage = userService.invalidMessage(signUpRequestDto);
 
         if (invalidMessage != ""){

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -6,6 +6,7 @@ import com.dope.breaking.dto.response.MessageResponseDto;
 import com.dope.breaking.dto.user.*;
 import com.dope.breaking.service.MediaService;
 import com.dope.breaking.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -77,18 +78,18 @@ public class UserAPI {
 
     }
 
-  
-
-    @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<MessageResponseDto> signInConfirm(
-            @RequestPart @Valid SignUpRequestDto signUpRequest,
+            @RequestPart String signUpRequest,
             @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
 
-        String invalidMessage = userService.invalidMessage(signUpRequest);
+        ObjectMapper mapper = new ObjectMapper();
+        SignUpRequestDto signUpRequestDto = mapper.readValue(signUpRequest,SignUpRequestDto.class);
+
+        String invalidMessage = userService.invalidMessage(signUpRequestDto);
 
         if (invalidMessage != ""){
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(invalidMessage));
+            return ResponseEntity.badRequest().body(new MessageResponseDto(invalidMessage));
         }
 
         String profileImgFileName = mediaService.getBasicProfileDir();
@@ -99,13 +100,13 @@ public class UserAPI {
 
         User user = new User(
                 profileImgFileName,
-                signUpRequest.getNickname(),
-                signUpRequest.getPhoneNumber(),
-                signUpRequest.getEmail(),
-                signUpRequest.getRealName(),
-                signUpRequest.getStatusMsg(),
-                signUpRequest.getUsername(),
-                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+                signUpRequestDto.getNickname(),
+                signUpRequestDto.getPhoneNumber(),
+                signUpRequestDto.getEmail(),
+                signUpRequestDto.getRealName(),
+                signUpRequestDto.getStatusMsg(),
+                signUpRequestDto.getUsername(),
+                Role.valueOf(signUpRequestDto.getRole().toUpperCase(Locale.ROOT))
         );
 
         userService.save(user);

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -10,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 
@@ -79,39 +76,26 @@ public class UserAPI {
 
     }
 
+//    @PutMapping("/profile/{userId}",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+//    public void updateProfile(
+//            @PathVariable(value = "userId") String userId,
+//            @RequestPart @Valid SignUpRequestDto signUpRequestDto,
+//            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception{
+//
+//
+//
+//    }
+
     @PostMapping(value = "/oauth2/sign-up",consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<MessageResponseDto> signInConfirm(
             @RequestPart @Valid SignUpRequestDto signUpRequest,
             @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
+        
+        String invalidateMessage = userService.invalidMessage(signUpRequest);
 
-        if(!userService.isValidRole(signUpRequest.getRole())){
+        if (invalidateMessage != ""){
             return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.INVALID_ROLE.getMessage()));
-        }
-
-        if(!userService.isValidEmailFormat(signUpRequest.getEmail())){
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.INVALID_EMAIL.getMessage()));
-        }
-
-        if(!userService.isValidPhoneNumberFormat(signUpRequest.getPhoneNumber())){
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.INVALID_PHONE_NUMBER.getMessage()));
-        }
-
-        if (userService.findByPhoneNumber(signUpRequest.getPhoneNumber()).isPresent()){
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.PHONE_NUMBER_DUPLICATE.getMessage()));
-        }
-
-        if (userService.findByEmail(signUpRequest.getEmail()).isPresent()) {
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.EMAIL_DUPLICATE.getMessage()));
-        }
-
-        if (userService.findByNickname(signUpRequest.getNickname()).isPresent()){
-            return ResponseEntity.badRequest()
-                    .body(new MessageResponseDto(SignUpErrorType.NICKNAME_DUPLICATE.getMessage()));
+                    .body(new MessageResponseDto(invalidateMessage));
         }
 
         String profileImgFileName = mediaService.getBasicProfileDir();

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -15,10 +15,13 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import java.io.File;
 import java.security.Principal;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
+import java.util.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -78,12 +81,32 @@ public class UserAPI {
     }
 
     @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<MessageResponseDto> signInConfirm(
+    public ResponseEntity<?> signInConfirm(
             @RequestPart String signUpRequest,
             @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
 
         ObjectMapper mapper = new ObjectMapper();
-        SignUpRequestDto signUpRequestDto = mapper.readValue(signUpRequest,SignUpRequestDto.class);
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+
+        //ObjectMapper의 readerFor는 @Valid가 적용되지 않습니다. 고로 validator로 추가 검증 절차가 필요합니다.
+        SignUpRequestDto signUpRequestDto = mapper.readerFor(SignUpRequestDto.class).readValue(signUpRequest);
+
+        //validator를 통해 User entity 중 @NotNull 조건은 만족하지 못하는 필드를 getPropertyPath()로 잡아냅니다.
+        Validator validator = factory.getValidator();
+        Set<ConstraintViolation<SignUpRequestDto>> violations = validator.validate(signUpRequestDto);
+
+        Map<String,String> nullFieldMap = new LinkedHashMap<>();
+        for (ConstraintViolation<SignUpRequestDto> violation : violations) {
+            nullFieldMap.put(String.valueOf(violation.getPropertyPath()),violation.getMessage());
+        }
+
+        //nullFieldList가 empty하지 않으면 있으면 안되는 null 값이 있다는 것입니다.
+        //고로 이 nullFieldList를 담은 map을 body에 넣어 400 HttpStatus를 전송합니다.
+        if(!nullFieldMap.isEmpty()){
+            return ResponseEntity.badRequest().body(nullFieldMap);
+        }
+
+        System.out.println("=========");
 
         String invalidMessage = userService.invalidMessage(signUpRequestDto);
 
@@ -115,13 +138,15 @@ public class UserAPI {
 
     }
 
+
     @PreAuthorize("isAuthenticated()")
     @PutMapping(value = "/profile", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
-    public ResponseEntity<MessageResponseDto> profileUpdateConfirm(
+    public ResponseEntity<?> profileUpdateConfirm(
             Principal principal,
-            @RequestPart String signUpRequest,
+            @RequestPart String updateRequest,
             @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
 
+        // 1. check the username (not_found / not registered)
         Optional<String> cntUsername = Optional.ofNullable(principal.getName());
 
         if (cntUsername.isEmpty()) {
@@ -132,39 +157,71 @@ public class UserAPI {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new MessageResponseDto(SignUpErrorType.NOT_REGISTERED_USER.getMessage()));
         }
 
+        // 2. create UpdateRequestDto with ObjectMapper (AND validation check)
+        ObjectMapper mapper = new ObjectMapper();
+        UpdateRequestDto updateRequestDto = mapper.readerFor(UpdateRequestDto.class).readValue(updateRequest);
+
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        Validator validator = factory.getValidator();
+        Set<ConstraintViolation<UpdateRequestDto>> violations = validator.validate(updateRequestDto);
+
+        Map<String,String> nullFieldMap = new LinkedHashMap<>();
+
+        for (ConstraintViolation<UpdateRequestDto> violation : violations) {
+            nullFieldMap.put(String.valueOf(violation.getPropertyPath()),violation.getMessage());
+        }
+
+        if(!nullFieldMap.isEmpty()){
+            return ResponseEntity.badRequest().body(nullFieldMap);
+        }
+
+        // 3. find the user by username.
         User user = userService.findByUsername(cntUsername.get()).get();
 
-        ObjectMapper mapper = new ObjectMapper();
-        SignUpRequestDto signUpRequestDto = mapper.readValue(signUpRequest,SignUpRequestDto.class);
+        // 4. validation (email, nickname, and phone number)
+        String invalidMessage = userService.invalidMessage(updateRequestDto,user);
 
-        String invalidMessage = userService.invalidMessage(signUpRequestDto);
+        if (!Objects.equals(invalidMessage, "")){
 
-        if (invalidMessage != ""){
-            if(user.getPhoneNumber() != signUpRequestDto.getPhoneNumber()
-                && user.getNickname() != signUpRequestDto.getNickname()
-                && user.getEmail() != signUpRequestDto.getEmail()){
-
-                return ResponseEntity.badRequest().body(new MessageResponseDto(invalidMessage));
-
-            }
+            return ResponseEntity.badRequest().body(new MessageResponseDto(invalidMessage));
 
         }
 
-        String profileImgFileName = mediaService.getBasicProfileDir();
+        // 5. update profile
 
-        if (profileImg != null){
+        String profileImgFileName = mediaService.getBasicProfileDir();
+        String originalProfileUrl = user.getProfileImgURL();
+
+        // case 1: 기본 이미지 -> 기본 이미지 : 변경 없음
+
+        // case 2: 유저 본인 선택 이미지 -> 기본 이미지
+        if (originalProfileUrl != mediaService.getBasicProfileDir() && profileImg == null){
+            File file = new File(mediaService.getDirName()+File.separator+originalProfileUrl);
+            file.delete();
+        }
+
+        // case 3: 기본 이미지 -> 유저 본인 선택 이미지
+        else if (originalProfileUrl == mediaService.getBasicProfileDir() && profileImg != null){
             profileImgFileName =  mediaService.uploadMedias(profileImg).get(0);
         }
 
+        // case 4: 유저 본인 선택 이미지 -> 유저 본인 선택 이미지
+        else if (originalProfileUrl != mediaService.getBasicProfileDir() && profileImg != null){
+            File file = new File(mediaService.getDirName()+File.separator+originalProfileUrl);
+            file.delete();
+            profileImgFileName =  mediaService.uploadMedias(profileImg).get(0);
+        }
+
+        // 6. update the user information
         user.setRequestFields(
                 profileImgFileName,
-                signUpRequestDto.getNickname(),
-                signUpRequestDto.getPhoneNumber(),
-                signUpRequestDto.getEmail(),
-                signUpRequestDto.getRealName(),
-                signUpRequestDto.getStatusMsg(),
-                signUpRequestDto.getUsername(),
-                Role.valueOf(signUpRequestDto.getRole().toUpperCase(Locale.ROOT))
+                updateRequestDto.getNickname(),
+                updateRequestDto.getPhoneNumber(),
+                updateRequestDto.getEmail(),
+                updateRequestDto.getRealName(),
+                updateRequestDto.getStatusMsg(),
+                cntUsername.get(),
+                Role.valueOf(updateRequestDto.getRole().toUpperCase(Locale.ROOT))
         );
 
         userService.save(user);

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -76,8 +76,7 @@ public class User {
 
     private String profileImgURL;
 
-    @Builder
-    public User (String generatedImgURL, String nickname, String phoneNumber, String email,
+    public void setRequestFields (String generatedImgURL, String nickname, String phoneNumber, String email,
              String realName, String statusMsg, String username, Role role) {
 
         this.profileImgURL = generatedImgURL;

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -58,10 +58,7 @@ public class User {
         this.role = role;
     }
 
-
-    private String firstname;
-
-    private String lastname;
+    private String realName;
 
     private String username;
 
@@ -79,16 +76,15 @@ public class User {
 
     private String profileImgURL;
 
-    public void signUp
-            (String generatedImgURL, String nickname, String phoneNumber, String email,
-             String firstname, String lastname, String statusMsg, String username, Role role) {
+    @Builder
+    public User (String generatedImgURL, String nickname, String phoneNumber, String email,
+             String realName, String statusMsg, String username, Role role) {
 
         this.profileImgURL = generatedImgURL;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.email = email;
-        this.firstname = firstname;
-        this.lastname = lastname;
+        this.realName = realName;
         this.statusMsg = statusMsg;
         this.username = username;
         this.balance = 0;

--- a/src/main/java/com/dope/breaking/dto/post/PostResType.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostResType.java
@@ -9,14 +9,12 @@ public enum PostResType {
     NOT_REGISTERED_USER("not registered user"),
     POST_FAILED("posting failed");
 
-
-
     private final String message;
-
 
     public String getMessage() {
 
         return this.message;
 
     }
+
 }

--- a/src/main/java/com/dope/breaking/dto/user/SignUpErrorType.java
+++ b/src/main/java/com/dope/breaking/dto/user/SignUpErrorType.java
@@ -7,8 +7,9 @@ public enum SignUpErrorType {
     INVALID_PHONE_NUMBER("invalid phone number"),
     EMAIL_DUPLICATE("used email"),
     PHONE_NUMBER_DUPLICATE("used phone number"),
-    NICKNAME_DUPLICATE("used nickname");
-
+    NICKNAME_DUPLICATE("used nickname"),
+    NOT_FOUND_USER("not found user"),
+    NOT_REGISTERED_USER("not registered user");
 
     private String message;
 

--- a/src/main/java/com/dope/breaking/dto/user/SignUpRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/SignUpRequestDto.java
@@ -19,9 +19,7 @@ public class SignUpRequestDto {
     @NotNull
     private String email;
     @NotNull
-    private String firstName;
-    @NotNull
-    private String lastName;
+    private String realName;
     @NotNull
     private String username;
     @NotNull

--- a/src/main/java/com/dope/breaking/dto/user/UpdateRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/UpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.dope.breaking.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateRequestDto {
+
+    private String statusMsg;
+    @NotNull
+    private String nickname;
+    @NotNull
+    private String phoneNumber;
+    @NotNull
+    private String email;
+    @NotNull
+    private String realName;
+    @NotNull
+    private String role;
+
+}
+
+

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -32,15 +32,17 @@ public class MediaService {
     private final MediaRepository mediaRepository;
 
     //디렉토리는 추후 AWS내의 디렉토리로 변경
-    //private final String dirName = "/Users/gimmin-u/Desktop/testImgFolder";
+    private final String dirName = "/Users/gimmin-u/Desktop/testImgFolder";
 
     //Martin0o0 dir
-    private final  String dirName = System.getProperty("user.dir") + "/files";
+    //private final String dirName = System.getProperty("user.dir") + "/files";
     private final String basicProfileDir = "profile.png";
 
     public String getBasicProfileDir() {
         return basicProfileDir;
     }
+
+    public String getDirName(){return dirName;}
 
     public List<String> uploadMedias(List<MultipartFile> medias) throws Exception{
 

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -36,6 +36,12 @@ public class MediaService {
 
     //Martin0o0 dir
     private final  String dirName = System.getProperty("user.dir") + "/files";
+    private final String basicProfileDir = "profile.png";
+
+    public String getBasicProfileDir() {
+        return basicProfileDir;
+    }
+
     public List<String> uploadMedias(List<MultipartFile> medias) throws Exception{
 
         List<String> fileNameList = new ArrayList<String>();

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.service;
 
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.SignUpErrorType;
+import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,10 +53,37 @@ public class UserService {
 
         String upperCasedRole = role.toUpperCase();
 
-        if (upperCasedRole.equals("PRESS") ||  upperCasedRole.equals("USER")){
-            return true;
+        return upperCasedRole.equals("PRESS") || upperCasedRole.equals("USER");
+
+    }
+
+    public String invalidMessage (SignUpRequestDto signUpRequest){
+
+        if(!isValidRole(signUpRequest.getRole())){
+            return SignUpErrorType.INVALID_ROLE.getMessage();
         }
-        return false;
+
+        if(!isValidEmailFormat(signUpRequest.getEmail())){
+            return SignUpErrorType.INVALID_EMAIL.getMessage();
+        }
+
+        if(!isValidPhoneNumberFormat(signUpRequest.getPhoneNumber())){
+            return SignUpErrorType.INVALID_PHONE_NUMBER.getMessage();
+        }
+
+        if (findByPhoneNumber(signUpRequest.getPhoneNumber()).isPresent()){
+            return SignUpErrorType.PHONE_NUMBER_DUPLICATE.getMessage();
+        }
+
+        if (findByEmail(signUpRequest.getEmail()).isPresent()) {
+            SignUpErrorType.EMAIL_DUPLICATE.getMessage();
+        }
+
+        if (findByNickname(signUpRequest.getNickname()).isPresent()){
+            return SignUpErrorType.NICKNAME_DUPLICATE.getMessage();
+        }
+
+        return "";
 
     }
 

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -3,11 +3,13 @@ package com.dope.breaking.service;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.user.SignUpErrorType;
 import com.dope.breaking.dto.user.SignUpRequestDto;
+import com.dope.breaking.dto.user.UpdateRequestDto;
 import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -76,10 +78,43 @@ public class UserService {
         }
 
         if (findByEmail(signUpRequest.getEmail()).isPresent()) {
-            SignUpErrorType.EMAIL_DUPLICATE.getMessage();
+            return SignUpErrorType.EMAIL_DUPLICATE.getMessage();
         }
 
         if (findByNickname(signUpRequest.getNickname()).isPresent()){
+            return SignUpErrorType.NICKNAME_DUPLICATE.getMessage();
+        }
+
+        return "";
+
+    }
+
+    public String invalidMessage (UpdateRequestDto updateRequest, User user){
+
+        if(!isValidRole(updateRequest.getRole())){
+            return SignUpErrorType.INVALID_ROLE.getMessage();
+        }
+
+        if(!isValidEmailFormat(updateRequest.getEmail())){
+            return SignUpErrorType.INVALID_EMAIL.getMessage();
+        }
+
+        if(!isValidPhoneNumberFormat(updateRequest.getPhoneNumber()) ){
+            return SignUpErrorType.INVALID_PHONE_NUMBER.getMessage();
+        }
+
+        if (findByPhoneNumber(updateRequest.getPhoneNumber()).isPresent()
+                && !Objects.equals(user.getPhoneNumber(), updateRequest.getPhoneNumber())) {
+            return SignUpErrorType.PHONE_NUMBER_DUPLICATE.getMessage();
+        }
+
+        if (findByEmail(updateRequest.getEmail()).isPresent()
+                && !Objects.equals(user.getEmail(), updateRequest.getEmail())) {
+            return SignUpErrorType.EMAIL_DUPLICATE.getMessage();
+        }
+
+        if (findByNickname(updateRequest.getNickname()).isPresent()
+                && !Objects.equals(user.getNickname(), updateRequest.getNickname())){
             return SignUpErrorType.NICKNAME_DUPLICATE.getMessage();
         }
 
@@ -110,5 +145,7 @@ public class UserService {
     public Boolean existByUsername(String username){
         return userRepository.existsByUsername(username);
     }
+
+    public void deleteUser(User user){userRepository.delete(user);}
 
 }

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -21,8 +21,7 @@ class UserRepositoryTest {
     void findByNickname() {
 
         //Given
-        User user = new User();
-        user.signUp("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu", "Kim","msg","username", Role.USER);
+        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
 
         //When
         User savedUser = userService.save(user);
@@ -37,8 +36,7 @@ class UserRepositoryTest {
     void findByPhoneNumber() {
 
         //Given
-        User user = new User();
-        user.signUp("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu", "Kim","msg","username",Role.USER);
+        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
 
         //When
         User savedUser = userService.save(user);
@@ -53,8 +51,7 @@ class UserRepositoryTest {
     void findByEmail() {
 
         //Given
-        User user = new User();
-        user.signUp("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu", "Kim","msg","username",Role.USER);
+        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
 
         //When
         User savedUser = userService.save(user);

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -21,7 +21,8 @@ class UserRepositoryTest {
     void findByNickname() {
 
         //Given
-        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+        User user = new User();
+        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
 
         //When
         User savedUser = userService.save(user);
@@ -36,7 +37,8 @@ class UserRepositoryTest {
     void findByPhoneNumber() {
 
         //Given
-        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
+        User user = new User();
+        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
 
         //When
         User savedUser = userService.save(user);
@@ -51,7 +53,8 @@ class UserRepositoryTest {
     void findByEmail() {
 
         //Given
-        User user = new User("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
+        User user = new User();
+        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
 
         //When
         User savedUser = userService.save(user);

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -66,7 +66,8 @@ class UserServiceTest {
                 ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","username", "PRess");
 
         // When
-        User user = new User(
+        User user = new User();
+        user.setRequestFields(
                 "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
@@ -83,6 +84,49 @@ class UserServiceTest {
         // Then
         User foundUser = userService.findById(savedUser.getId()).get();
         Assertions.assertThat(foundUser).isEqualTo(user);
+
+    }
+
+    @Test
+    void updateUser(){
+        // Given
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","username", "PRess");
+
+        User user = new User();
+        user.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+
+        userService.save(user);
+
+        //When
+        User updatedUser = userService.findById(1L).get();
+        updatedUser.setRequestFields(
+                "anyURL",
+                "newNickname",
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+
+        userService.save(updatedUser);
+
+        //Then
+        User foundUser = userService.findById(1L).get();
+
+        Assertions.assertThat(foundUser.getId()).isEqualTo(1L);
+        Assertions.assertThat(foundUser.getNickname()).isEqualTo("newNickname");
 
     }
 

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -63,18 +63,15 @@ class UserServiceTest {
 
         // Given
         SignUpRequestDto signUpRequest =  new SignUpRequestDto
-                ("nickname","phoneNumber", "mwk300@nyu.edu","Minwu","Kim","msg","username", "PRess");
+                ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","username", "PRess");
 
         // When
-        User user = new User();
-
-        user.signUp(
+        User user = new User(
                 "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
-                signUpRequest.getFirstName(),
-                signUpRequest.getLastName(),
+                signUpRequest.getRealName(),
                 signUpRequest.getStatusMsg(),
                 signUpRequest.getUsername(),
                 Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #29 

## 예상 리뷰 시간
40-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- firstName, lastName을  realName으로 수정했습니다.
- 회원가입시 사용자가 프로필사진을 선정하지 않았을 때 기본 프로필 사진으로 설정하는 로직을 도입했습니다. 
   - 기본 프사의 주소는 MediaService에 임시로 만들어 놓았습니다 (스크린 샷 참고). 추후에 변경하면 됩니다.
   
- json과 Multipart를 받아올 수 가 없어 스트링으로 처리하는 로직을 도입했습니다.
   -  ObjectMapper를 쓰면 String에서 dto로 손쉬운 매핑이 가능합니다.
   - 다만 NotNull 등의 validation이 자동 지원이 되지 않아 Validator를 통해 직접 구현했습니다.
   - 앞으로도 필요한 경우 이렇게 매핑하면 될 것 같습니다.
   - API sheet 역시 이에 맞게 수정하였습니다. 
  
- 프로필 수정시 UpdateRequestDto로 클라이언트의 요청을 처리합니다.
   - SignUpRequest와 유일하게 다른 점은 클라이언트가 "username"을 받아오지 않는 것입니다.
   - username 은 principal 객체를 통해 자체적으로 받아옵니다. 

 - 이메일, 전화번호 및 닉네임의 중복검사 및 형식검사를 위한 invalidMessage 메서드를 생성했습니다.
   - **여기서 String을 == 으로 비교하여 if문을 처리했을때 원하는대로 동작하지 않았습니다.**
   - 꼭!  == 대신 equal를 쓰시길 바랍니다. 
   - invalidMessage 구현과 아래 "기타"를 잘 읽어주시기 바랍니다. 

- 프로필 사진 수정 업데이트 기능을 구현했습니다. 업데이트시 기존의 사진은 삭제하고 현재 사진만 남깁니다.
   - 네가지 케이스를 분류해서 구현했습니다:
    1. 기본 프사 -> 기본 프사
    2. 본인 프사 -> 기본 프사
    3. 기본 프사 -> 본인 프사
    4. 본인 프사1 -> 본인 프사2




## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
1. 기본 프로필 사진 

<img width="888" alt="스크린샷 2022-07-06 오전 12 14 45" src="https://user-images.githubusercontent.com/87322089/177361008-08599f75-8d67-49db-b846-701570883464.png">

- 본인 로컬에서 테스트하고 싶으신 경우 알아서 변경하시길 바랍니다. 

2.  String으로 매핑 후 validation

<img width="888" alt="스크린샷 2022-07-06 오전 12 23 03" src="https://user-images.githubusercontent.com/87322089/177362572-204b2626-7e28-45f2-85d3-f6be26eaf58c.png">

- 위와 같이 잘 동작하는 것을 볼 수 있습니다. 
- 다만 프론트 쪽에서 구현만 잘 해놓는다면 터지지 않을 이슈입니다. 혹시 모를 2차방어를 위해 구현하였습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
1. 수정 기능 구현시 이메일, 닉네임 및 전화번호 중복검사를 구현하는데 빠뜨릴 뻔 했던 게 있습니다. 앞으로 이런 상황이 또 생길 것 같아 공유합니다:
    - 예를 들어보겠습니다. 어느 사용자의 전화번호는 01012345678이고, 이메일은 "hello@gmail.com" 이라고 해봅시다.
    - 사용자가 전화번호는 변경하지 않고, 이메일만 "bye@gmail.com"으로 변경하고 싶습니다.
    - 클라이언트는 UpdateRequest에 전화번호 "01012345678" 과 "bye@gmail.com"를 담아 보냅니다.
    - **여기서 그대로 findByPhoneNumber로 중복 검사를 하면 안됩니다.**  기존 DB에 저장되어있는 본인의 번호와 중복되기 때문입니다.
    - 따라서, 중복이 발생할 경우 본인의 종전 번호와 중복인지, 아니면 다른사람과 중복인지 검증하는 추가적인 절차가 필요합니다. 
    - 이 문제가 터지는 근본적인 이유는 우리가 "전화번호 수정", "이메일 수정" 이런 식으로 따로 기능 구현을 한 것이 아닌, 정보 하나만 바뀌어도 모든 필드값을 다 클라이언트에서 다시 받아오는 식으로 구현했기 때문입니다. 
   
2.  앞서 언급했듯, String은 == 대신 Objects.equals  사용하시기 바랍니다.
