### PR TITLE
feat:Issuing jwt tokens after registering as a member

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -5,10 +5,12 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.PostResType;
 import com.dope.breaking.dto.response.MessageResponseDto;
 import com.dope.breaking.dto.user.*;
+import com.dope.breaking.security.jwt.JwtTokenProvider;
 import com.dope.breaking.service.MediaService;
 import com.dope.breaking.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,7 @@ public class UserAPI {
 
     private final UserService userService;
     private final MediaService mediaService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/oauth2/sign-up/validate-phone-number")
     public ResponseEntity<MessageResponseDto> validatePhoneNumber(@RequestBody PhoneNumberValidateRequestDto phoneNumberValidateRequest){
@@ -132,8 +135,10 @@ public class UserAPI {
         );
 
         userService.save(user);
-
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        String accessjwt = jwtTokenProvider.createAccessToken(signUpRequestDto.getUsername());
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.set("Authorization", accessjwt);
+        return ResponseEntity.status(HttpStatus.CREATED).headers(httpHeaders).build();
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #54 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
기존에는 회원가입 후 다시 로그인을 행하여 jwt 토큰을 발행하는 방식이였지만, 회원가입 후 바로 Jwt 토큰을 발행하여 자동으로 로그인 처리를합니다.

## 스크린샷
<img width="705" alt="스크린샷 2022-07-08 오후 12 14 11" src="https://user-images.githubusercontent.com/62254434/177910176-7e62a870-4005-4ad9-93db-777d5413c911.png">


## 기타
이상입니다.
