### PR TITLE
feat: security test with MockMvc

### DIFF
--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -49,15 +49,11 @@ class PostAPITest {
     @Autowired
     UserRepository userRepository;
 
-
     @Autowired
     PasswordEncoder passwordEncoder;
 
-
-    private String jwt;
-
-    @BeforeEach
-    public void createToken() {
+    @BeforeEach //DB에 유저정보를 먼저 저장.
+    public void createUserInfo() {
       User  user = User.builder()
                 .username("12345g")
                 .password(passwordEncoder.encode(UUID.randomUUID().toString()))
@@ -68,7 +64,7 @@ class PostAPITest {
     }
 
 
-    @AfterEach
+    @AfterEach //테스트 후 DB 정보 모두 삭제.
     public void aftercleanup() {
         userRepository.deleteAll();
     }

--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -1,0 +1,97 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.security.jwt.JwtTokenProvider;
+import com.dope.breaking.service.UserService;
+import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.io.FileInputStream;
+import java.util.UUID;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc // @WebMvcTest와 가장 큰 차이점은 컨트롤러 뿐만 아니라 테스트 대상이 아닌 @Service나 @Repository가 붙은 객체들도 모두 메모리에 올린다. 즉, 서비스단과 컨트롤러단의 테스트가 가능해짐.
+class PostAPITest {
+
+    @Autowired
+    private MockMvc mockMvc; //컨트롤러 테스트 하기위한 도구인 MockMvc를 사용. 위에서 자동으로 설정해주는 어노테이션 덕분에 의존성 주입이 필요없다.
+
+    @Autowired
+    PostAPI postAPI;
+
+    @Autowired
+    UserService userService;
+
+    @Autowired
+    UserRepository userRepository;
+
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+
+    private String jwt;
+
+    @BeforeEach
+    public void createToken() {
+      User  user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userService.save(user);
+    }
+
+
+    @AfterEach
+    public void aftercleanup() {
+        userRepository.deleteAll();
+    }
+
+    @DisplayName("POST 등록 테스트")
+    @WithMockCustomUser
+    @Test
+    public void testpost() throws Exception{
+        MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.jpg", "image/png", new FileInputStream(System.getProperty("user.dir") + "/files/test1.png"));
+
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.multipart("/posttest")
+                        .file(multipartFile1)
+                        .content("hello")
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+
+        Assertions.assertThat(content.contains("hello")).isTrue();
+
+    }
+}

--- a/src/test/java/com/dope/breaking/withMockCustomAuthorize/WithMockCustomUser.java
+++ b/src/test/java/com/dope/breaking/withMockCustomAuthorize/WithMockCustomUser.java
@@ -1,0 +1,14 @@
+package com.dope.breaking.withMockCustomAuthorize;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String username() default "12345g";
+
+    String role() default "USER";
+}

--- a/src/test/java/com/dope/breaking/withMockCustomAuthorize/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/dope/breaking/withMockCustomAuthorize/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,36 @@
+package com.dope.breaking.withMockCustomAuthorize;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser>{
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        List<GrantedAuthority> grantedAuthorities = new ArrayList();
+        grantedAuthorities.add(new SimpleGrantedAuthority(annotation.role()));
+        User principal = new User(annotation.username(), "1234567890", true, true, true, true,
+                grantedAuthorities);
+        System.out.println(principal.getUsername());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                principal, principal.getPassword(), principal.getAuthorities());
+        System.out.println(authentication.getName());
+        context.setAuthentication(authentication);
+        return context;
+    }
+
+    public String getUsername(WithMockCustomUser withMockCustomUser){
+        return withMockCustomUser.username();
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #51 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
1. 모의 인증 어노테이션을 통해 컨트롤러단에서의 테스트 코드가 가능해 졌습니다.
  컨트롤러와 서비스단의 테스트를 가능하게 해주는 MockMvc를 사용함으로써 테스트가 가능해 졌습니다.
  MockMvc 테스트 방식은 예시를 참고하여 주십시오. 더 자세한 설명은 타 블로그 및 공식 문서를 살펴보시면 제가 설명하는것 보다 더 자세히 살펴보실 수 있습니다. 
 - 공식 문서 : https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/test/web/servlet/MockMvc.html
 - 참고한 블로그 : 
   - 1. https://velog.io/@jkijki12/Spring-MockMvc
   - 2. https://ykh6242.tistory.com/entry/Spring-Web-MVC-Multipart-요청-다루기
2. @WithMockCustomUser 어노테이션을 붙여줌으로써, "모의로 인증을 받았다고 강제로 시큐리티 컨텍스트에 저장한 유저"를 바탕으로 컨트롤러에 접근할 수 있게되었습니다. 이는 테스트 코드를 살펴보시면 어디에 사용해야 할지 이해되실 것이라 생각됩니다.
  - 유저 정보는 다음과 같습니다. 
  - username : 12345g
  - Role : USER

3. 실질적으로 @PreAuthorize("isAuthenticate()")를 사용하는 입장으로써, Pincipal의 유저 정보를 가져와서 유저를 찾습니다. 그렇기에, 테스트코드를 작성 시, @BeforeEach 문에서 먼저, 유저 정보를 담아주어야 합니다. 제가 작성한 예시를 보시면 바로 이해 되실 겁니다.

4. 예시로  미디어 플랫폼 컨셉인 만큼, MultiPartFile을 테스트하는 방식으로 예시를 작성하였습니다. 자세한 사용 설명에 관한 부분은 위에 기술한 블로그나, 공식 문서를 통해 살펴보시면 더 이해가 되실 것이라 생각됩니다.

## 스크린샷
<img width="1047" alt="스크린샷 2022-07-09 오후 1 51 45" src="https://user-images.githubusercontent.com/62254434/178092761-8ddb1c33-a3e0-4ae8-b97e-4d1975579eeb.png">

<img width="1487" alt="스크린샷 2022-07-09 오후 1 53 42" src="https://user-images.githubusercontent.com/62254434/178092775-d8f63177-ca8e-4dca-b001-baebdb7c422a.png">


<img width="1668" alt="스크린샷 2022-07-09 오후 2 22 30" src="https://user-images.githubusercontent.com/62254434/178092812-d0d123a4-3cf7-4917-add6-e87b6f25df50.png">



## 기타
이미 인증된 UserPasswordAuthenticationToken를 발행한 시점이기 때문에 더이상 jwt 토큰을 통해 유저 정보를 찾고 발행하는 필요가 없어졌습니다. 이번 테스크 코드를 통해 보다 빠르고, 쉬운 테스트 코드 환경이 조성되었으면 좋겠습니다. 이상입니다.
