### PR TITLE
feat: implement validate JWT token API for remember-me

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -142,6 +142,12 @@ public class UserAPI {
 
     }
 
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/oauth2/validate-jwt")
+    public ResponseEntity<UserBriefInformationResponseDto> validateJwt(Principal principal) {
+        return ResponseEntity.ok().body(userService.userBriefInformation(principal.getName()));
+    }
+
 
     @PreAuthorize("isAuthenticated()")
     @PutMapping(value = "/profile", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/dope/breaking/dto/user/UserBriefInformationResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/UserBriefInformationResponseDto.java
@@ -1,0 +1,16 @@
+package com.dope.breaking.dto.user;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserBriefInformationResponseDto {
+
+    String profileImgURL;
+
+    String nickname;
+
+    Long userId;
+
+}

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -5,6 +5,8 @@ import com.dope.breaking.dto.post.PostResType;
 import com.dope.breaking.dto.user.SignUpErrorType;
 import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.dto.user.UpdateRequestDto;
+import com.dope.breaking.dto.user.UserBriefInformationResponseDto;
+import com.dope.breaking.exception.oauth.InvalidAccessTokenException;
 import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -165,6 +167,12 @@ public class UserService {
 
     public Boolean existById(Long userId){
         return userRepository.existsById(userId);
+    }
+
+    public UserBriefInformationResponseDto userBriefInformation(String username) {
+
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        return new UserBriefInformationResponseDto(user.getProfileImgURL(), user.getNickname(), user.getId());
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #45 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 클라이언트에서 자동 로그인 시, 최초에 요청하는 API를 만들었습니다.
- JWT 토큰이 현재 유효한지 검사합니다. (시큐리티에서 isAuthenticated() 1차 검증을 하고, service 계층에서 추가적인 체크를 합니다.)
- 로그인 API와 동일하게, 기본적인 유저 정보를 반환합니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/178101143-9082a34d-2c8c-46a1-9b65-f65b3b63f2a4.png)
![image](https://user-images.githubusercontent.com/76773202/178101219-6e708ad3-7592-48a5-8ad8-359aab4ea69d.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
다음 작업을 할 때 제가 이번에 작성한 코드를 참고해주세요.
- 예외처리
- 응답처리
- 테스트코드 (성공/실패(+예외) 케이스)

그리고 테스트코드의 네이밍에 대해서도 한 번 생각해보고, 통일을 하는게 좋을 것 같습니다.