### PR TITLE
feat: exceaption bug fix

### DIFF
--- a/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
+++ b/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
@@ -32,7 +32,7 @@ public class CustomExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponseDto> handleCustomException(BreakingException e) {
+    protected ResponseEntity<ErrorResponseDto> handleCustomException(Exception e) {
 
         log.error(e.getMessage());
         return ResponseEntity

--- a/src/main/java/com/dope/breaking/exception/auth/InvalidAccessTokenFromOauth2Exception.java
+++ b/src/main/java/com/dope/breaking/exception/auth/InvalidAccessTokenFromOauth2Exception.java
@@ -1,0 +1,2 @@
+package com.dope.breaking.exception.auth;public class InvalidAccessTokenFromOauth2Exception {
+}

--- a/src/main/java/com/dope/breaking/exception/auth/InvalidAccessTokenFromOauth2Exception.java
+++ b/src/main/java/com/dope/breaking/exception/auth/InvalidAccessTokenFromOauth2Exception.java
@@ -1,2 +1,14 @@
-package com.dope.breaking.exception.auth;public class InvalidAccessTokenFromOauth2Exception {
+package com.dope.breaking.exception.auth;
+
+import com.dope.breaking.exception.BreakingException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAccessTokenFromOauth2Exception extends BreakingException {
+
+    private static final String MESSAGE = "유효하지 않은 Oauth2 AccessToken입니다." ;
+
+    public InvalidAccessTokenFromOauth2Exception() {
+        super(MESSAGE, HttpStatus.NOT_ACCEPTABLE);
+    }
 }
+

--- a/src/main/java/com/dope/breaking/security/controller/Oauth2LoginController.java
+++ b/src/main/java/com/dope/breaking/security/controller/Oauth2LoginController.java
@@ -1,10 +1,12 @@
 package com.dope.breaking.security.controller;
 
 
+import com.dope.breaking.exception.auth.InvalidAccessTokenFromOauth2Exception;
 import com.dope.breaking.security.jwt.JwtTokenProvider;
 import com.dope.breaking.security.userInfoDto.InvalidAccessTokenResponse;
 import com.dope.breaking.security.userInfoDto.UserDto;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.service.Oauth2LoginService;
 import com.dope.breaking.service.UserService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +18,7 @@ import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.RestTemplate;
 
+import javax.validation.constraints.Null;
 import java.util.Map;
 
 @Slf4j
@@ -23,182 +26,24 @@ import java.util.Map;
 @RequestMapping("/oauth2/sign-in")
 @RestController
 public class Oauth2LoginController {
-    private final UserService userService;
 
-    private final JwtTokenProvider jwtTokenProvider;
 
-    @PostMapping("/naver")
-    public ResponseEntity<?> naverOAuthRedirect(@RequestBody Map<String, String> accessToken) throws ParseException, JsonProcessingException, ParseException {
-        // RestTemplate 인스턴스 생성
-        RestTemplate restTemplate = new RestTemplate();
-        String token = accessToken.get("accessToken");
-        log.info("access token : {} ", token);
-
-        JSONParser jsonParser = new JSONParser();
-        //header를 생성해서 access token을 넣어주고
-        HttpHeaders profileRequestHeader = new HttpHeaders();
-        profileRequestHeader.add("Authorization", "Bearer " + token);
-
-        HttpEntity<HttpHeaders> profileHttpEntity = new HttpEntity<>(profileRequestHeader);
-
-        // profile api로 생성해둔 헤더를 담아서 요청을 보냅니다.
-        ResponseEntity<String> profileResponse = restTemplate.exchange(
-                "https://openapi.naver.com/v1/nid/me",
-                HttpMethod.POST,
-                profileHttpEntity,
-                String.class
-        );
-
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(profileResponse.getBody());
-        log.info(jsonObject.toJSONString());
-        String userinfo = jsonObject.get("response").toString();
-        JSONObject infoObject = (JSONObject) jsonParser.parse(userinfo);
-        UserDto dto = new UserDto();
-        dto.setFullname(infoObject.get("name").toString());
-        dto.setUsername(infoObject.get("id").toString());
-        dto.setEmail(infoObject.get("email").toString());
-        log.info(dto.toString());
-        User user = userService.findByUsername(dto.getUsername()).orElse(null);
-        if (user == null) {
-            log.info("유저 정보가 없음");
-            return ResponseEntity.status(200).body(dto);
-        } else {
-            log.info("유저 정보 있다.");
-            String accessjwt = jwtTokenProvider.createAccessToken(user.getUsername());
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
-        }
-    }
+    private final Oauth2LoginService oauth2LoginService;
 
 
     @PostMapping("/kakao")
-    public ResponseEntity<?> kakaoOauthLogin(@RequestBody Map<String, String> accessToken) throws ParseException {
-        HttpHeaders headers = new HttpHeaders();
-        RestTemplate restTemplate = new RestTemplate();
+    public ResponseEntity<?> kakaoOauthLogin(@RequestBody Map<String, String> accessToken) throws InvalidAccessTokenFromOauth2Exception, ParseException {
         String token = accessToken.get("accessToken");
-
-        headers.add("Authorization", "Bearer " + token);
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        HttpEntity<HttpHeaders> kakaoRequest1 = new HttpEntity<>(headers);
-        ResponseEntity<String> kakaoUserinfo;
-        try {
-            kakaoUserinfo = restTemplate.exchange(
-                    "https://kapi.kakao.com/v2/user/me",
-                    HttpMethod.POST,
-                    kakaoRequest1,
-                    String.class
-            );
-        } catch (Exception e) {
-            log.info(e.toString());
-            InvalidAccessTokenResponse invalidAccessTokenResponse = new InvalidAccessTokenResponse();
-            invalidAccessTokenResponse.setAccessToken(token);
-            invalidAccessTokenResponse.setErrorMessage("유효하지 않은 AccessToken");
-            invalidAccessTokenResponse.setIdToken("Kakao에서는 필요하지 않는 Token");
-            return new ResponseEntity<InvalidAccessTokenResponse>(invalidAccessTokenResponse, HttpStatus.NOT_ACCEPTABLE); //유효하지 않은 토큰이라고 에러메시지 표출.
-        }
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoUserinfo.getBody());
-        log.info(jsonObject.toJSONString());
-        UserDto dto = new UserDto();
-        dto.setUsername(jsonObject.get("id").toString()+"k");
-        String kakao_account = jsonObject.get("kakao_account").toString();
-        JSONObject infoObject = (JSONObject) jsonParser.parse(kakao_account);
-        log.info(infoObject.toJSONString());
-        try {
-            dto.setEmail(infoObject.get("email").toString());
-        } catch (Exception e) {
-            log.info("이메일 정보를 불러올 수 없음");
-            dto.setEmail(null);
-        }
-        String profile = infoObject.get("profile").toString();
-        infoObject = (JSONObject) jsonParser.parse(profile);
-        try {
-            dto.setFullname(infoObject.get("nickname").toString());
-        } catch (Exception e) {
-            log.info("유저 이름을 불러올 수 없음");
-            dto.setFullname(null);
-        }
-        try {
-            dto.setProfileImgURL(infoObject.get("profile_image_url").toString());
-        } catch (Exception e) {
-            log.info("기존 프로필 사진을 불러올 수 없음");
-            dto.setProfileImgURL(null);
-        }
-
-        if (!userService.existByUsername(dto.getUsername())) {
-            log.info("기존 유저 정보가 없음.");
-            return ResponseEntity.status(200).body(dto);
-        } else {
-            log.info("기존 유저 정보가 있음.");
-            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
-        }
+        ResponseEntity<String> kakaoUserinfo = oauth2LoginService.kakaoUserInfo(token);
+        return oauth2LoginService.kakaoLogin(kakaoUserinfo);
     }
 
 
     @PostMapping("/google")
-    public ResponseEntity<?> googleOauthLogin(@RequestBody Map<String, String> accessToken) throws ParseException {
-        HttpHeaders headers = new HttpHeaders();
-        RestTemplate restTemplate = new RestTemplate();
+    public ResponseEntity<?> googleOauthLogin(@RequestBody Map<String, String> accessToken) throws InvalidAccessTokenFromOauth2Exception, ParseException {
         String token = accessToken.get("accessToken");
         String idtoken = accessToken.get("idToken");
-
-        headers.add("Authorization", "Bearer " + token);
-        ResponseEntity<String> GoogleUserinfo;
-        try {
-            HttpEntity profileRequest = new HttpEntity(headers);
-            GoogleUserinfo = restTemplate.exchange(
-                    "https://oauth2.googleapis.com/tokeninfo?id_token=" + idtoken,
-                    HttpMethod.GET,
-                    profileRequest,
-                    String.class
-            );
-        } catch (Exception e) {
-            log.info(e.toString());
-            InvalidAccessTokenResponse invalidAccessTokenResponse = new InvalidAccessTokenResponse();
-            invalidAccessTokenResponse.setAccessToken(token);
-            invalidAccessTokenResponse.setIdToken(idtoken);
-            invalidAccessTokenResponse.setErrorMessage("유효하지 않는 토큰 존재.");
-
-            return new ResponseEntity<InvalidAccessTokenResponse>(invalidAccessTokenResponse, HttpStatus.NOT_ACCEPTABLE); //유효하지 않은 토큰이라고 에러메시지 표출.
-        }
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(GoogleUserinfo.getBody());
-        log.info(jsonObject.toJSONString());
-        UserDto dto = new UserDto();
-        dto.setUsername(jsonObject.get("sub").toString()+"g");
-        try {
-            dto.setEmail(jsonObject.get("email").toString());
-        } catch (Exception e) {
-            log.info("이메일 정보를 불러올 수 없음");
-            dto.setEmail(null);
-        }
-        try {
-            dto.setFullname(jsonObject.get("given_name").toString());
-        } catch (Exception e) {
-            log.info("유저 이름을 불러올 수 없음");
-            dto.setFullname(null);
-        }
-        try {
-            dto.setProfileImgURL(jsonObject.get("picture").toString());
-        } catch (Exception e) {
-            log.info("기존 프로필 사진을 불러올 수 없음");
-            dto.setProfileImgURL(null);
-        }
-
-        if (!userService.existByUsername(dto.getUsername())) {
-            log.info("유저 정보가 없음");
-            return ResponseEntity.status(200).body(dto);
-        } else {
-            log.info("유저 정보가 있다.");
-            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
-            HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", accessjwt);
-            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
-        }
+        ResponseEntity<String> GoogleUserinfo = oauth2LoginService.googleUserInfo(token, idtoken);
+        return oauth2LoginService.googleLogin(GoogleUserinfo);
     }
 }

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -1,0 +1,156 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.exception.auth.InvalidAccessTokenFromOauth2Exception;
+import com.dope.breaking.security.jwt.JwtTokenProvider;
+import com.dope.breaking.security.userInfoDto.UserDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.coyote.Response;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class Oauth2LoginService {
+
+    private final UserService userService;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+
+    public ResponseEntity<String> kakaoUserInfo(String accessToken){
+        HttpHeaders headers = new HttpHeaders();
+        RestTemplate restTemplate = new RestTemplate();
+
+        headers.add("Authorization", "Bearer " + accessToken);
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<HttpHeaders> kakaoRequest1 = new HttpEntity<>(headers);
+        ResponseEntity<String> kakaoUserinfo = null;
+        try {
+            kakaoUserinfo = restTemplate.exchange(
+                    "https://kapi.kakao.com/v2/user/me",
+                    HttpMethod.POST,
+                    kakaoRequest1,
+                    String.class
+            );
+        } catch (Exception e) {
+            log.info(e.toString());
+            throw new InvalidAccessTokenFromOauth2Exception();
+        }
+        return kakaoUserinfo;
+    }
+
+    public ResponseEntity<?> kakaoLogin(ResponseEntity<String> kakaoUserinfo) throws ParseException {
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(kakaoUserinfo.getBody());
+        log.info(jsonObject.toJSONString());
+        UserDto dto = new UserDto();
+        dto.setUsername(jsonObject.get("id").toString() + "k");
+        String kakao_account = jsonObject.get("kakao_account").toString();
+        JSONObject infoObject = (JSONObject) jsonParser.parse(kakao_account);
+        log.info(infoObject.toJSONString());
+        if(infoObject.containsKey("email")){
+            dto.setEmail(infoObject.get("email").toString());
+        }else {
+            log.info("이메일 정보를 불러올 수 없음");
+            dto.setEmail(null);
+        }
+        String profile = infoObject.get("profile").toString();
+        infoObject = (JSONObject) jsonParser.parse(profile);
+        if(infoObject.containsKey("nickname")){
+            dto.setFullname(infoObject.get("nickname").toString());
+        } else {
+            log.info("유저 이름을 불러올 수 없음");
+            dto.setFullname(null);
+        }
+
+        if(infoObject.containsKey("profile_image_url")){
+            dto.setProfileImgURL(infoObject.get("profile_image_url").toString());
+        } else {
+            log.info("기존 프로필 사진을 불러올 수 없음");
+            dto.setProfileImgURL(null);
+        }
+
+        if (!userService.existByUsername(dto.getUsername())) {
+            log.info("기존 유저 정보가 없음.");
+            return ResponseEntity.status(200).body(dto);
+        } else {
+            log.info("기존 유저 정보가 있음.");
+            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.set("Authorization", accessjwt);
+            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
+        }
+    }
+
+    public ResponseEntity<String> googleUserInfo(String accessToken, String idToken){
+        HttpHeaders headers = new HttpHeaders();
+        RestTemplate restTemplate = new RestTemplate();
+        headers.add("Authorization", "Bearer " + accessToken);
+        ResponseEntity<String> GoogleUserinfo = null;
+        try {
+            HttpEntity profileRequest = new HttpEntity(headers);
+            GoogleUserinfo = restTemplate.exchange(
+                    "https://oauth2.googleapis.com/tokeninfo?id_token=" + idToken,
+                    HttpMethod.GET,
+                    profileRequest,
+                    String.class
+            );
+        } catch (Exception e) {
+            log.info(e.toString());
+            throw new InvalidAccessTokenFromOauth2Exception();
+        }
+        return GoogleUserinfo;
+    }
+
+
+
+    public ResponseEntity<?> googleLogin(ResponseEntity<String> GoogleUserinfo) throws ParseException {
+        JSONParser jsonParser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) jsonParser.parse(GoogleUserinfo.getBody());
+        log.info(jsonObject.toJSONString());
+        UserDto dto = new UserDto();
+        dto.setUsername(jsonObject.get("sub").toString() + "g");
+
+        if(jsonObject.containsKey("email")){
+            dto.setEmail(jsonObject.get("email").toString());
+        }else{
+            log.info("유저 이메일을 불러올 수 없음");
+            dto.setEmail(null);
+        }
+
+        if(jsonObject.containsKey("given_name")) {
+            dto.setFullname(jsonObject.get("given_name").toString());
+        }else{
+            log.info("유저 이름을 불러올 수 없음");
+            dto.setFullname(null);
+        }
+
+        if(jsonObject.containsKey("picture")){
+
+            dto.setProfileImgURL(jsonObject.get("picture").toString());
+        }else{
+            log.info("기존 프로필 사진을 불러올 수 없음");
+            dto.setProfileImgURL(null);
+        }
+
+        if (!userService.existByUsername(dto.getUsername())) {
+            log.info("유저 정보가 없음");
+            return ResponseEntity.status(200).body(dto);
+        } else {
+            log.info("유저 정보가 있다.");
+            String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.set("Authorization", accessjwt);
+            return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
+        }
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #71 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
1. 일단, oauth2LoginController단의 로직들을 모두 Service단으로 옮겼습니다. 컨트롤러단이 너무 지져분해 보였기 때문입니다.

2. 새로운  BreakingException을 상속받는 예외 클래스를 생성하여 예외처리를 커스텀 하였습니다. 
  클라이언트가 유요하지 않은 Oauth2 토큰으로 접근하여 하였을 때 발생하는 커스텀 오류입니다. 406 NOT_ACCEPT로 반환하도록 하였습니다.

3. 마지막으로 선택적 동의사항의 null 처리가 변경되었습니다. 기존에는 선택하지 않은 동의가 있다면 강제로 예외를 터트려 null을 반환하도록 로직이 구현되었었지만, if else문으로 try catch문을 최소화 하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="1034" alt="스크린샷 2022-07-12 오후 4 25 09" src="https://user-images.githubusercontent.com/62254434/178435332-40a812a3-d484-4231-ba70-34b5abc33e60.png">
<img width="1042" alt="스크린샷 2022-07-12 오후 4 25 00" src="https://user-images.githubusercontent.com/62254434/178435354-1f831fe1-c999-4103-a494-47d42ab66567.png">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
커스텀 예외처리를 응용해 볼 수 있었습니다.