### PR TITLE
feat: implement refresh token for access token

### DIFF
--- a/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
+++ b/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
@@ -22,6 +22,7 @@ public class CustomExceptionHandler {
                 .body(new ErrorResponseDto("서버 내부 오류"));
     }
 
+
     @ExceptionHandler(BreakingException.class)
     protected ResponseEntity<ErrorResponseDto> handleBreakingCustomException(BreakingException e) {
 
@@ -31,13 +32,5 @@ public class CustomExceptionHandler {
                 .body(new ErrorResponseDto(e.getMessage()));
     }
 
-    @ExceptionHandler(Exception.class)
-    protected ResponseEntity<ErrorResponseDto> handleCustomException(Exception e) {
-
-        log.error(e.getMessage());
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(new ErrorResponseDto("서버 내부 오류"));
-    }
 
 }

--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -147,5 +147,4 @@ public class PostAPI {
         }
         return ResponseEntity.status(HttpStatus.OK).body("Post is Modified");
     }
-
 }

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -51,9 +51,11 @@ public class UserAPI {
             @RequestPart (required = false) List<MultipartFile> profileImg) {
 
         String username = userService.signUp(signUpRequest, profileImg);
-
         HttpHeaders httpHeaders = new HttpHeaders();
         httpHeaders.set("Authorization", jwtTokenProvider.createAccessToken(username));
+        String refreshjwt = jwtTokenProvider.createRefreshToken();
+        httpHeaders.set("Authorization-refresh", refreshjwt);
+        userService.setRefreshToken(username, refreshjwt); //리플리쉬 토큰 저장.
         return ResponseEntity.status(HttpStatus.CREATED).headers(httpHeaders).build();
 
     }

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -76,6 +76,10 @@ public class User {
 
     private String profileImgURL;
 
+    @Column(length = 1000)
+    private String refreshToken;
+
+
     public void setRequestFields (String generatedImgURL, String nickname, String phoneNumber, String email,
              String realName, String statusMsg, String username, Role role) {
 
@@ -97,5 +101,16 @@ public class User {
     public String getRoleKey(){
         return this.role.getKey();
     }
+
+
+    public void updateRefreshToken(String refreshToken){
+        this.refreshToken = refreshToken;
+    }
+
+    public void destroyRefreshToken(){
+        this.refreshToken = null;
+    }
+
+
 
 }

--- a/src/main/java/com/dope/breaking/repository/UserRepository.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepository.java
@@ -14,4 +14,7 @@ public interface UserRepository extends JpaRepository<User,Long> {
 
     Boolean existsByUsername(String username);
 
+
+    Optional<User> findByRefreshToken(String refreshToken);
+
 }

--- a/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
@@ -13,6 +13,8 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("*")
                 .allowedMethods("*")
-                .allowedHeaders("*");
+                .allowedHeaders("*")
+                .exposedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityconfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityconfig.java
@@ -5,6 +5,7 @@ import com.dope.breaking.security.jwt.JwtAuthenticationFilter;
 import com.dope.breaking.security.jwt.JwtEntryPoint;
 import com.dope.breaking.security.jwt.JwtTokenProvider;
 import com.dope.breaking.security.userDetails.PrincipalDetailsService;
+import com.dope.breaking.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -31,6 +32,8 @@ public class WebSecurityconfig extends WebSecurityConfigurerAdapter {
     private final PrincipalDetailsService principalDetailsService;
 
     private final PasswordEncoder passwordEncoder;
+
+    private final UserService userService;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -66,7 +69,7 @@ public class WebSecurityconfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService);
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService, userService);
         return jwtAuthenticationFilter;
     }
 }

--- a/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
@@ -2,9 +2,7 @@ package com.dope.breaking.security.jwt;
 
 import com.dope.breaking.security.userDetails.PrincipalDetailsService;
 import com.dope.breaking.service.UserService;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.MalformedJwtException;
-import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -12,6 +10,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -35,63 +34,48 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//모든 서�
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
 
-        String accesstoken = jwtTokenProvider.extractAccessToken(request).orElse(null); //accesstoken으로 받아졌는지 확인
-        log.info("accessToken :  {}" , accesstoken );
-        String refreshtoken = jwtTokenProvider.extractRefreshToken(request).orElse(null); //refreshtoken으로 받야졌는지 확인
-        log.info("refreshToken : {}", refreshtoken);
+        String accesstoken = jwtTokenProvider.extractAccessToken(request).orElse(null);
+        String refreshtoken = jwtTokenProvider.extractRefreshToken(request).orElse(null);
 
-
-        //엑세스 토큰은 null이 아니고 엑세스 토큰이 유효하다면
-
-        /*
-        refresh토큰이 우선적으로 유효한지를 살펴보아야 한다고 생각함. 그리고 유효하다면? 재발행한다. 엑세스 토큰만 주는 경우는 접근하기 위함이고, refresh토큰을 지녔다는 것은 재발행 요청을 했다는 뜻. 둘다 보내도, 리플리쉬 토큰을 보냈음으로 재발행한다.
-         */
-        if(refreshtoken != null && jwtTokenProvider.validateToken(refreshtoken) == true){
+        if (refreshtoken != null && jwtTokenProvider.validateToken(refreshtoken) == true) {
             log.info(String.valueOf(userService.findByRefreshToken(refreshtoken).isPresent()));
-            if(userService.findByRefreshToken(refreshtoken).isPresent()){
+            if (userService.findByRefreshToken(refreshtoken).isPresent()) {
 
                 String reissueAccessToken = jwtTokenProvider.createAccessToken(userService.findByRefreshToken(refreshtoken).get().getUsername());
                 response.setStatus(HttpServletResponse.SC_OK);
                 response.setHeader("Authorization", reissueAccessToken);
                 Map<String, String> responseBody = new HashMap<>();
-                responseBody.put("message", "AccessToken 재발급 완료");
-                return; //바로 반환한다.
+                responseBody.put("message", "Access Token 재발급이 완료되었습니다.");
+                return;
+            } else {
+                request.setAttribute("exception", "Refresh Token이 유효하지 않습니다.");
             }
-            else{
-                request.setAttribute("exception", "RefreshToken is invalid");
-            }
-        }
-        else if (accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == true) {
+        } else if (accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == true) {
 
             String username = jwtTokenProvider.getUsername(accesstoken);
             log.info(username);
 
             try {
                 UserDetails userDetails = principalDetailsService.loadUserByUsername(username);
-                log.info("Userdetail : {}", userDetails.getUsername());
-                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());//비밀번호는 인증단계에서는 필요없으므로,
+                Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(), userDetails.getAuthorities());
 
-                SecurityContext context = SecurityContextHolder.createEmptyContext(); //컨텍스트 텅 비어있는 컨텍스트 객체 생성
-                context.setAuthentication(authentication);//SecurityContext에 Authentication 객체를 저장
-                SecurityContextHolder.setContext(context); //contextholder에 authentication 객체를 저장한 컨텍스트를 담게함.
-            }
-            catch(Exception e){
+                SecurityContext context = SecurityContextHolder.createEmptyContext();
+                context.setAuthentication(authentication);
+                SecurityContextHolder.setContext(context);
+            } catch (UsernameNotFoundException e) {
                 log.info("유저 정보 찾지 못함");
-                request.setAttribute("exception", "User Not Found");
+                request.setAttribute("exception", "유저 정보를 찾지 못했습니다.");
             }
-            //스프링 시큐리티가 수행해주는 권한 처리를 위해 아래와 같이 토큰을 만들어서 Authentication 객체를 강제로 만들고 컨텍스트에 저장한다.
-
-            //다음 체인필터로 이동
-        }
-        else if(accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == false){
+        } else if (accesstoken != null && jwtTokenProvider.validateToken(accesstoken) == false) {
             try {
-                String username = jwtTokenProvider.getUsername(accesstoken); //해독 과정 중 에러가 발생함.
-            } catch (SecurityException | MalformedJwtException | IllegalArgumentException e) {
-                request.setAttribute("exception", "Invalid Signature");
-            } catch (ExpiredJwtException e) {
-                request.setAttribute("exception", "Expiration date");
-            } catch (Exception e) {
-                request.setAttribute("exception", "Other errors related to jwt");
+                String username = jwtTokenProvider.getUsername(accesstoken);
+            }catch (ExpiredJwtException e) {
+                log.info("Expiraion date");
+                request.setAttribute("exception", "Access Token이 만료되었습니다.");
+            }
+            catch (SecurityException | IllegalArgumentException | JwtException e) {
+                log.info("invalid sign");
+                request.setAttribute("exception", "Access Token이 유효하지 않습니다.");
             }
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.security.jwt;
 
+import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
@@ -8,6 +10,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 public class JwtEntryPoint implements AuthenticationEntryPoint {
 
     @Override
@@ -15,14 +18,15 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
                          AuthenticationException authException) throws IOException {
 
         String exception = (String) request.getAttribute("exception");
-
         if (exception != null) {
             setResponse(response, exception);
-        }else{
+        }
+        //jwt 없이 접급하려고 할때.
+        if(authException instanceof InsufficientAuthenticationException){
             JSONObject responseJson = new JSONObject();
             response.setContentType("application/json;charset=UTF-8");
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-            responseJson.put("message", "Jwt token is required");
+            responseJson.put("message", "로그인이 필요합니다.");
 
             response.getWriter().print(responseJson);
         }

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -84,8 +84,11 @@ public class Oauth2LoginService {
         } else {
             log.info("기존 유저 정보가 있음.");
             String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
+            String refreshjwt = jwtTokenProvider.createRefreshToken();
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("Authorization", accessjwt);
+            httpHeaders.set("Authorization-refresh", refreshjwt);
+            userService.setRefreshToken(dto.getUsername(), refreshjwt);
             return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
         }
     }
@@ -147,8 +150,11 @@ public class Oauth2LoginService {
         } else {
             log.info("유저 정보가 있다.");
             String accessjwt = jwtTokenProvider.createAccessToken(dto.getUsername());
+            String refreshjwt = jwtTokenProvider.createRefreshToken();
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("Authorization", accessjwt);
+            httpHeaders.set("Authorization-refresh", refreshjwt);
+            userService.setRefreshToken(dto.getUsername(), refreshjwt);
             return new ResponseEntity<String>("토큰 발행", httpHeaders, HttpStatus.OK);
         }
     }

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
@@ -264,5 +265,15 @@ public class UserService {
         return userRepository.existsById(userId);
     }
 
-    
+
+
+    public Optional<User> findByRefreshToken(String refreshToken){
+        return userRepository.findByRefreshToken(refreshToken);
+    }
+
+    @Transactional
+    public void setRefreshToken(String username, String refreshToken){
+        User user = userRepository.findByUsername(username).get();
+        user.updateRefreshToken(refreshToken);
+    }
 }

--- a/src/test/java/com/dope/breaking/security/controller/Oauth2LoginControllerTest.java
+++ b/src/test/java/com/dope/breaking/security/controller/Oauth2LoginControllerTest.java
@@ -54,9 +54,7 @@ class Oauth2LoginControllerTest {
     @DisplayName("구글 Oauth2 로그인")
     @Test
     void googleOauthLogin() throws Exception {
-        String accesstoken = "ya29.A0AVA9y1uxYysIWVXbntvBZMNkYZnWdDaYo4xZCZwZP_msI7sDQlu_TygXhrUm5nccF8wlLSFBBJuiSNIojztNc88h5HwDuiSuNO6I2_OvTr7opR28-RJkeHZBSlDIQgqQFmWG3UjfpVoY2lmcv4JG3ne51GjYtAYUNnWUtBVEFTQVRBU0ZRRTY1ZHI4cjVTR0M2ek5EWVBSOU53Tkh1S1UzQQ0165";
-        String idtoken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFiZDY4NWY1ZThmYzYyZDc1ODcwNWMxZWIwZThhNzUyNGM0NzU5NzUiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDQ0MzEyNjk4ODIwNjA1NjIxMzUiLCJoZCI6ImtodS5hYy5rciIsImVtYWlsIjoiY2h5MDMxMEBraHUuYWMua3IiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiYXRfaGFzaCI6Im5UQWF3d292azZWc0F4SXRCRWlYUGciLCJuYW1lIjoi4oCN7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUl0YnZtbUp0RTBrMXo1T2hUMm5OcHpsZjV6anBiUm0yVWJOeEliaDQwcWw9czk2LWMiLCJnaXZlbl9uYW1lIjoi7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJmYW1pbHlfbmFtZSI6IuKAjSIsImxvY2FsZSI6ImtvIiwiaWF0IjoxNjU3NTM0NzU0LCJleHAiOjE2NTc1MzgzNTR9.kA6z_ABgsiai-MMQ_rUDiTajsas9RR3Vac57G4w9BKPMmRP8KxjAXhO-3I9mQ6lsYVB3NkbztS2dBg1d1mDdHd7qgLxkpE358KmmaYzmTEu971GZ6sN35N-1KSgszkQ92wM-pibgYGXlfI4xxMXYaotU8jWuVT7YcnqSYc0mHsR_iK4cK7q6f11kzUHSvArln-QQB6Ea7QgSX9f5SxAPoKtx_Uj3tbScVJTrfjW6AqcOsxx-jxaJ_EJQJGaAzWmnOYqKPquKk4d9fv7cnWGD75G8EdZG9_j9KrHQ3_0RN-LA_C7g092DU9yx8Vjly86dT1uC19trKVWdtfPBf_SQbg";
-
+        String accesstoken = ""; String idtoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -71,8 +69,8 @@ class Oauth2LoginControllerTest {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.fullname").value("최현영[학생](소프트웨어융합대학 컴퓨터공학부)"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.username").value("104431269882060562135g"))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.email").value("chy0310@khu.ac.kr"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.username").value(""))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.email").value(""))
                 .andReturn();
 
         MockHttpServletResponse response = result.getResponse();

--- a/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,237 @@
+package com.dope.breaking.security.jwt;
+
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.security.userDetails.PrincipalDetailsService;
+import com.dope.breaking.service.UserService;
+import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.aspectj.lang.annotation.Before;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import javax.swing.text.html.Option;
+import java.security.Principal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class JwtAuthenticationFilterTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Autowired
+    PrincipalDetailsService principalDetailsService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private static String USERNAME = "2318483287k";
+    private static String PASSWORD = "123456789";
+
+    static String accessjwt;
+    static String refreshjwt;
+
+
+    @DisplayName("AccessJwt and RefreshJwt issue")
+    @Order(1)
+    @Test
+    void IssueJwtWithkakaoOauthLogin() throws Exception {
+        userRepository.deleteAll();
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+
+        String accesstoken = "vdICZpZVx_AMd_Jm8_uu7QpNK0xhPQH8Lyu7azL8Cj11XAAAAYHw4mnS";
+        //String idtoken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFiZDY4NWY1ZThmYzYyZDc1ODcwNWMxZWIwZThhNzUyNGM0NzU5NzUiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDQ0MzEyNjk4ODIwNjA1NjIxMzUiLCJoZCI6ImtodS5hYy5rciIsImVtYWlsIjoiY2h5MDMxMEBraHUuYWMua3IiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiYXRfaGFzaCI6IlRHWVV2b0JnZlVzclJEdWNCam1zTkEiLCJuYW1lIjoi4oCN7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUl0YnZtbUp0RTBrMXo1T2hUMm5OcHpsZjV6anBiUm0yVWJOeEliaDQwcWw9czk2LWMiLCJnaXZlbl9uYW1lIjoi7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJmYW1pbHlfbmFtZSI6IuKAjSIsImxvY2FsZSI6ImtvIiwiaWF0IjoxNjU3NTk0NTcwLCJleHAiOjE2NTc1OTgxNzB9.ay4i1huUnRZbfne0T1EBGQ5JLCJ5auP_E9BLeFqco7xuGF0W0m2RPKMSkGUpZ_8QDjmNh0RbGTLn-ycF9SXafWg37jl-HF2F7xoSmpvwmt53YDK2YH-3DvlaMc9wQI8IvaqFB5B-vr0FG9Cjf-iuBGVVgCAV0ZjCH_rxdZYlnO7b2Nz305hx5KFAWZ34yIkx3qbqV449DUWsGlnV6okyom9visVXhkrmXFRg3KZJBoeDLlI37qcdv7LeCDmlr9orFgFwT8GjAPaL0dDBGhQL_n534ZkV-Z2IF0UuAwseKe2IhxBbIIDnkJyIAL_pI8jMdJP_R6KJ7FsKgYyUN445kA";
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + userRepository.findByRefreshToken(refreshjwt).get().getRefreshToken());
+    }
+
+    @DisplayName("No AccessJwt and RefreshJwt")
+    @Order(2)
+    @Test
+    void noAccessAndRefreshToken() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/validate-jwt"))//login이 아닌 다른 임의의 주소
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError()); //아무것도 없다면 4xx 반환
+    }
+
+    @DisplayName("valid AccessJwt without RefreshJwt")
+    @Order(3)
+    @Test
+    void validAccessWithoutRefreshToken() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization", "Bearer " + accessjwt))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()); //엑세스 토큰이 유효하다면 2xx 반환
+    }
+
+    @DisplayName("invalid Accessjwt without RefreshJwt")
+    @Order(4)
+    @Test
+    void invalidAccessWithoutRefreshToken() throws Exception{
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization", "Bearer " + accessjwt + "123456"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError()); //엑세스 토큰이 유효하지 않다면 4xx 반환.
+    }
+
+
+
+    @DisplayName("valid RefreshJwt without AccessJwt")
+    @Order(5)
+    @Test
+    void validRefreshWithoutAccessToken() throws Exception{
+
+        System.out.println(refreshjwt);
+        System.out.println(userRepository.findByUsername(USERNAME).get().getRefreshToken());
+
+
+        MvcResult result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization-refresh", "Bearer " + refreshjwt))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn(); //재발급이기 때문.
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        String reaccessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println(reaccessjwt);
+    }
+
+
+    @DisplayName("invalid RefershJwt without AccessToken") //유효하지 않은 refreshtoken으로 접근하면 4xx 발생
+    @Order(6)
+    @Test
+    void invalidRefreshWithoutAccessToken() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization-refresh", "Bearer " + refreshjwt+ "1214"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError());
+    }
+
+
+    @DisplayName("valid AccessJwt and RefreshJwt")
+    @Order(7)
+    @Test
+    void validAccessAndRefreshToken() throws Exception{
+        MvcResult result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt) //accessjwt
+                        .header("Authorization-refresh", "Bearer " + refreshjwt))//refershjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn(); //재발급이기 때문.
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        System.out.println("refershToken : " + response.getHeaderValue("Authorization-refresh"));
+        String reaccessjwt = (String) response.getHeaderValue("Authorization");
+        String rerefreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        Assertions.assertThat(rerefreshjwt).isNull();
+        System.out.println(reaccessjwt);
+    }
+
+    @DisplayName("invalid  AccessJwt but valid RefreshJwt") //유효기간 또는 잘못된 시그니처를 포함한 엑세스 토큰과 올바른 refresh 토큰이 같이 왔다면 재발행.
+    @Order(8)
+    @Test
+    void invalidAccessButValidRefresh() throws Exception{
+        MvcResult result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt+ "2134") //accessjwt
+                        .header("Authorization-refresh", "Bearer " + refreshjwt))//refershjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn(); //refresh 토큰이 유효하기에 재발급함.
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        System.out.println("refershToken : " + response.getHeaderValue("Authorization-refresh"));
+        String reaccessjwt = (String) response.getHeaderValue("Authorization");
+        String rerefreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        Assertions.assertThat(reaccessjwt).isNotEmpty();
+        Assertions.assertThat(rerefreshjwt).isNull();
+        System.out.println(reaccessjwt);
+
+    }
+
+
+
+    @DisplayName("Valid AccessJwt but Invalid RefreshJwt")
+    @Order(9)
+    @Test
+    void validAccessButinvalidRefresh() throws Exception{
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt)
+                        .header("Authorization-refresh", "Bearer " + refreshjwt+ "1214"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+
+    @DisplayName("Invalid AccessJwt and RefershJwt")
+    @Order(10)
+    @Test
+    void invalidAccessAndRefresh() throws Exception{
+        MvcResult result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt+ "2134") //accessjwt
+                        .header("Authorization-refresh", "Bearer " + refreshjwt + "1245"))//refershjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError()).andReturn(); //모두 잘못된 토큰이기에 4xx
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        System.out.println("refershToken : " + response.getHeaderValue("Authorization-refresh"));
+        String reaccessjwt = (String) response.getHeaderValue("Authorization");
+        String rerefreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        Assertions.assertThat(reaccessjwt).isNull();
+        Assertions.assertThat(rerefreshjwt).isNull();
+    }
+
+
+
+
+}

--- a/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
@@ -60,7 +60,7 @@ class JwtAuthenticationFilterTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private static String USERNAME = "2318483287k";
+    private static String USERNAME = "";
     private static String PASSWORD = "123456789";
 
     static String accessjwt;
@@ -75,8 +75,7 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "vdICZpZVx_AMd_Jm8_uu7QpNK0xhPQH8Lyu7azL8Cj11XAAAAYHw4mnS";
-        //String idtoken = "eyJhbGciOiJSUzI1NiIsImtpZCI6IjFiZDY4NWY1ZThmYzYyZDc1ODcwNWMxZWIwZThhNzUyNGM0NzU5NzUiLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI3MzY0NTMzMjUxMzItYjNqcmVydTJzaTQydTltYnFudjBuOWVxdmNucDQxMDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMDQ0MzEyNjk4ODIwNjA1NjIxMzUiLCJoZCI6ImtodS5hYy5rciIsImVtYWlsIjoiY2h5MDMxMEBraHUuYWMua3IiLCJlbWFpbF92ZXJpZmllZCI6dHJ1ZSwiYXRfaGFzaCI6IlRHWVV2b0JnZlVzclJEdWNCam1zTkEiLCJuYW1lIjoi4oCN7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJwaWN0dXJlIjoiaHR0cHM6Ly9saDMuZ29vZ2xldXNlcmNvbnRlbnQuY29tL2EvQUl0YnZtbUp0RTBrMXo1T2hUMm5OcHpsZjV6anBiUm0yVWJOeEliaDQwcWw9czk2LWMiLCJnaXZlbl9uYW1lIjoi7LWc7ZiE7JiBW-2VmeyDnV0o7IaM7ZSE7Yq47Juo7Ja07Jy17ZWp64yA7ZWZIOy7tO2TqO2EsOqzte2Vmeu2gCkiLCJmYW1pbHlfbmFtZSI6IuKAjSIsImxvY2FsZSI6ImtvIiwiaWF0IjoxNjU3NTk0NTcwLCJleHAiOjE2NTc1OTgxNzB9.ay4i1huUnRZbfne0T1EBGQ5JLCJ5auP_E9BLeFqco7xuGF0W0m2RPKMSkGUpZ_8QDjmNh0RbGTLn-ycF9SXafWg37jl-HF2F7xoSmpvwmt53YDK2YH-3DvlaMc9wQI8IvaqFB5B-vr0FG9Cjf-iuBGVVgCAV0ZjCH_rxdZYlnO7b2Nz305hx5KFAWZ34yIkx3qbqV449DUWsGlnV6okyom9visVXhkrmXFRg3KZJBoeDLlI37qcdv7LeCDmlr9orFgFwT8GjAPaL0dDBGhQL_n534ZkV-Z2IF0UuAwseKe2IhxBbIIDnkJyIAL_pI8jMdJP_R6KJ7FsKgYyUN445kA";
+        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);

--- a/src/test/java/com/dope/breaking/security/jwt/TestController.java
+++ b/src/test/java/com/dope/breaking/security/jwt/TestController.java
@@ -1,0 +1,18 @@
+package com.dope.breaking.security.jwt;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/hello")
+    public ResponseEntity<?> hello() {
+        System.out.println("hello");
+        return ResponseEntity.ok().body("hello");
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #62 

## 예상 리뷰 시간
35-min

## 추가 또는 변경사항
1. Refresh 토큰을 추가하였습니다.
 기존에는 Access 토큰만 발행하였지만, 이번 Refresh 토큰을 발행함으로써 사용자는 만료기간 이전에, 혹은 만료기간 이후 Refresh 토큰을 가지고 Access토큰을 재발급 받을 수 있습니다.

2. 인증된 유저만 접근할 수 있는 url에 접근을 시도하려 할 시, Access 및 Refresh 토큰을 사용할 경우 경우는 다음과 같습니다.
  a. Access 토큰 및 Refresh 토큰 없이 접근하려고 할 시 4xx 응답을 반환합니다.
  b. 유효한 Access 토큰으로만 접근하려 할 시 2xx 정상응답을 반환합니다.
  c. 유효하지 않은 Access 토큰으로만 접근하려 할 시 4xx 응답을 반환합니다.
  d. 유효한 Refresh 토큰으로만 접근하려 할 시 Access 토큰이 재발행됩니다.
  e. 유효하지 않은 refresh 토큰으로만 접근하려 할 시 4xx 응답을 반환합니다.
  f.  유효한 Access 토큰과 Refresh 토큰으로 접근하려 할 시 Access 토큰이 재발행됩니다.
  g. 유효하지 않은 Access 토큰과 유효한 Refresh 토큰으로 접근하려 할 시 Access 토큰이 재발행됩니다.
  h. 유효한 Access 토큰과 유효하지 않은 Refresh 토큰으로 접근하려 할 시 2xx 응답을 반환합니다.
  i.  유효하지않은 Access 토큰과 Refresh 토큰으로 접근하려 할 시 4xx 응답을 반환합니다.

3. CustomExceptionHandler의 최상위 예외클래스인 Exception 클래스를 삭제하였습니다. 

4. DB에 refresh 토큰을 저장하도록 설계하였습니다. 요청에 해당하는 refresh 토큰을 지닌 유저를 찾기 위함입니다.

5. 예외 메시지를 한글로 수정하였습니다. 

6. cors 설정을 수정하였습니다. 클라이언트 단으로 요청받을 때 헤더의 내용을 받기 위함입니다.
## 스크린샷
<img width="399" alt="스크린샷 2022-07-13 오전 11 07 36" src="https://user-images.githubusercontent.com/62254434/178642507-6dc16901-233d-4abb-a054-afc513abdf2c.png">


## 기타
다음으로 로그아웃 기능을 구현하겠습니다.
