### PR TITLE
feat: implement user page information API

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -79,4 +79,9 @@ public class UserAPI {
 
     }
 
+    @GetMapping("/profile/{userId}")
+    public ResponseEntity<ProfileInformationResponseDto> profileInformation(@PathVariable Long userId){
+        return ResponseEntity.ok().body(userService.profileInformation(userId));
+    }
+
 }

--- a/src/main/java/com/dope/breaking/dto/user/ProfileInformationResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/ProfileInformationResponseDto.java
@@ -1,0 +1,43 @@
+package com.dope.breaking.dto.user;
+
+import com.dope.breaking.domain.user.Role;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@Setter
+public class ProfileInformationResponseDto {
+
+    Long userId;
+
+    @NotNull
+    String profileImgURL;
+
+    String nickname;
+
+    String email;
+
+    String statusMsg;
+
+    Role role;
+
+    int followerCount;
+
+    int followingCount;
+
+    @Builder
+    public ProfileInformationResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followerCount, int followingCount) {
+        this.userId = userId;
+        this.profileImgURL = profileImgURL;
+        this.nickname = nickname;
+        this.email = email;
+        this.statusMsg = statusMsg;
+        this.role = role;
+        this.followerCount = followerCount;
+        this.followingCount = followingCount;
+    }
+
+}

--- a/src/main/java/com/dope/breaking/repository/FollowRepository.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepository.java
@@ -1,7 +1,15 @@
 package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.user.Follow;
+import com.dope.breaking.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+    //팔로워 수
+    int countFollowsByFollowing(User user);
+
+    //팔로잉 수
+    int countFollowsByFollowed(User user);
+
 }

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -71,10 +71,6 @@ class UserAPITest {
         mockMvc.perform(get("/profile/" + 1000000000))
                 .andExpect(status().isNotFound());
 
-        ProfileInformationResponseDto build = ProfileInformationResponseDto.builder()
-                .userId(1L)
-                .build();
-        System.out.println("build = " + build);
     }
 
 }

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -1,0 +1,80 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.ProfileInformationResponseDto;
+import com.dope.breaking.dto.user.SignUpRequestDto;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Locale;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserAPITest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private UserRepository userRepository;
+
+    @Test
+    void getProfileInformationSuccess() throws Exception {
+        User user = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        user.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(user);
+
+        mockMvc.perform(get("/profile/" + user.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value(user.getId()));
+
+    }
+
+
+    @Test
+    void getProfileInformationFailure() throws Exception {
+        User user = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        user.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(user);
+
+        mockMvc.perform(get("/profile/" + 1000000000))
+                .andExpect(status().isNotFound());
+
+        ProfileInformationResponseDto build = ProfileInformationResponseDto.builder()
+                .userId(1L)
+                .build();
+        System.out.println("build = " + build);
+    }
+
+}

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -1,0 +1,100 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.user.Follow;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.SignUpRequestDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class FollowRepositoryTest {
+
+    @Autowired UserRepository userRepository;
+    @Autowired FollowRepository followRepository;
+    @Autowired EntityManager em;
+
+    @Test
+    void countFollowerAndFollowing() {
+
+        User hero = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        hero.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(hero);
+
+        User follower1 = new User();
+        SignUpRequestDto signUpRequest2 =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        follower1.setRequestFields(
+                "anyURL",
+                signUpRequest2.getNickname(),
+                signUpRequest2.getPhoneNumber(),
+                signUpRequest2.getEmail(),
+                signUpRequest2.getRealName(),
+                signUpRequest2.getStatusMsg(),
+                signUpRequest2.getUsername(),
+                Role.valueOf(signUpRequest2.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(follower1);
+
+        User follower2 = new User();
+        SignUpRequestDto signUpRequest3 =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        follower2.setRequestFields(
+                "anyURL",
+                signUpRequest3.getNickname(),
+                signUpRequest3.getPhoneNumber(),
+                signUpRequest3.getEmail(),
+                signUpRequest3.getRealName(),
+                signUpRequest3.getStatusMsg(),
+                signUpRequest3.getUsername(),
+                Role.valueOf(signUpRequest3.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(follower2);
+
+
+        Follow follow1 = new Follow();
+
+        follow1.updateFollowing(hero);
+        follow1.updateFollowed(follower1);
+        follower1.getFollowingList().add(follow1);
+        hero.getFollowerList().add(follow1);
+
+        // ==================
+
+        Follow follow2 = new Follow();
+
+        follow2.updateFollowing(hero);
+        follow2.updateFollowed(follower2);
+
+        follower2.getFollowingList().add(follow2);
+        hero.getFollowerList().add(follow2);
+
+        assertEquals(2, followRepository.countFollowsByFollowing(hero));
+        assertEquals(0, followRepository.countFollowsByFollowed(hero));
+
+        assertEquals(1, followRepository.countFollowsByFollowed(follower1));
+        assertEquals(1, followRepository.countFollowsByFollowed(follower2));
+
+        assertEquals(0, followRepository.countFollowsByFollowing(follower1));
+        assertEquals(0, followRepository.countFollowsByFollowing(follower2));
+    }
+}

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -2,9 +2,11 @@ package com.dope.breaking.service;
 
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.ProfileInformationResponseDto;
 import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.dto.user.UserBriefInformationResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class UserServiceTest {
 
     @Autowired UserService userService;
+    @Autowired UserRepository userRepository;
     @Autowired EntityManager em;
 
 //    @Test
@@ -227,6 +230,31 @@ class UserServiceTest {
 
         //Then
         assertNotEquals(foundUserInfo.getUserId(), user.getId());
+    }
+
+    @Test
+    void getUserInformationInProfilePage() {
+
+        User user = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        user.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(user);
+
+        ProfileInformationResponseDto profileInformationResponseDto = userService.profileInformation(user.getId());
+
+        assertThat(profileInformationResponseDto.getEmail().equals(user.getEmail()));
+        assertThat(profileInformationResponseDto.getNickname().equals(user.getNickname()));
+
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #41 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
유저 페이지에서 유저의 기본 정보에 대해 조회합니다.
해당 유저 정보는 로그인 한 유저와 로그인 하지 않은 유저에 대한 차이를 두지 않습니다.


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
컨트롤러 레이어 테스트 방법에 대해서 노션에 정리하였습니다.