### PR TITLE
Feat/97 implement media file response api

### DIFF
--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -42,11 +42,8 @@ public class MediaService {
 
     private final PostRepository postRepository;
 
-    //디렉토리는 추후 AWS내의 디렉토리로 변경
-    //private final String dirName = "/Users/gimmin-u/Desktop/testImgFolder";
 
-    //Martin0o0 dir
-    private final String dirName = System.getProperty("user.dir") + "/files";
+    private final String dirName = System.getProperty("user.dir") + "/src/main/resources/static";
     private final String basicProfileDir = "profile.png";
 
     public String getBasicProfileDir() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,13 @@ spring:
       enabled: true
       path: /console
 
+  mvc:
+    static-path-pattern: /static/**
+
+  resources:
+    static-locations: classpath:/static/
+    add-mappings: true
+
 
   servlet:
     multipart:


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #87 

## 예상 리뷰 시간
2-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 사진과 동영상을 저장할 폴더를 resources/static 으로 설정했습니다.
- 클라이언트가 직접 파일에 접근할수 있도록 applications.yml 파일을 재설정했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
없음


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 파일을 클라이언트쪽으로 쏴주는 방식을 변경했습니다:
  - 기존에는 클라이언트가 url을 보내면 백엔드 쪽에서 해당되는 파일을 보내는 방식으로 구현할 계획이었습니다.
  - 하지만 지금 클라이언트는  url 을 가지고 직접 파일을 resources/static 에 접근하여 꺼내옵니다.
- 기존 방식을 유지했던 이유는 파일의 보안 문제 때문이었습니다. (포스트 숨김처리 등 문제) 하지만 깻묵님과 토론해본 결과 나름의 해결방안을 찾았습니다:
  - 포스트를 숨길 시 파일의 uuid값을 재설정합니다.
  - 그럴 경우 타 유저는 uuid를 알 수 없기 때문에 파일에 접근이 불가합니다.
  - 다만 우려되는 요소는 모든 유저가 "resources/static"에 모든 파일에 접근하는 가능성이었는데, 다행히도 그건 AWS에서 자체적으로 막아놓은 것을 확인할 수 있었습니다. 