### PR TITLE
feat: implement full user information API

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -2,10 +2,8 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.dto.user.*;
 import com.dope.breaking.security.jwt.JwtTokenProvider;
-import com.dope.breaking.service.MediaService;
 import com.dope.breaking.service.UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +19,6 @@ import java.util.*;
 public class UserAPI {
 
     private final UserService userService;
-    private final JwtTokenProvider jwtTokenProvider;
 
 
     @GetMapping("/oauth2/sign-up/validate-phone-number/{phoneNumber}")
@@ -80,5 +77,12 @@ public class UserAPI {
         }
         return ResponseEntity.ok().body(userService.profileInformation(userName, userId));
     }
+
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/profile/detail")
+    public ResponseEntity<FullUserInformationResponse> fullUserInformation(Principal principal) {
+        return ResponseEntity.ok().body(userService.getFullUserInformation(principal.getName()));
+    }
+
 
 }

--- a/src/main/java/com/dope/breaking/dto/user/FullUserInformationResponse.java
+++ b/src/main/java/com/dope/breaking/dto/user/FullUserInformationResponse.java
@@ -1,0 +1,34 @@
+package com.dope.breaking.dto.user;
+
+import com.dope.breaking.domain.user.Role;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class FullUserInformationResponse {
+
+    String nickname;
+
+    String phoneNumber;
+
+    String email;
+
+    String realName;
+
+    Role role;
+
+    String statusMsg;
+
+	String profileImgURL;
+
+    @Builder
+    public FullUserInformationResponse(String nickname, String phoneNumber, String email, String realName, Role role, String statusMsg, String profileImgURL) {
+        this.nickname = nickname;
+        this.phoneNumber = phoneNumber;
+        this.email = email;
+        this.realName = realName;
+        this.role = role;
+        this.statusMsg = statusMsg;
+        this.profileImgURL = profileImgURL;
+    }
+}

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -2,10 +2,7 @@ package com.dope.breaking.service;
 
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
-import com.dope.breaking.dto.user.ProfileInformationResponseDto;
-import com.dope.breaking.dto.user.SignUpRequestDto;
-import com.dope.breaking.dto.user.UpdateUserRequestDto;
-import com.dope.breaking.dto.user.UserBriefInformationResponseDto;
+import com.dope.breaking.dto.user.*;
 import com.dope.breaking.exception.CustomInternalErrorException;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.user.DuplicatedUserInformationException;
@@ -295,5 +292,18 @@ public class UserService {
                 .isFollowing(isFollowing)
                 .build();
 
+    }
+
+    public FullUserInformationResponse getFullUserInformation(String username) {
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        return FullUserInformationResponse.builder()
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .email(user.getEmail())
+                .realName(user.getRealName())
+                .role(user.getRole())
+                .statusMsg(user.getStatusMsg())
+                .profileImgURL(user.getProfileImgURL())
+                .build();
     }
 }

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.dope.breaking.service;
 
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.FullUserInformationResponse;
 import com.dope.breaking.dto.user.ProfileInformationResponseDto;
 import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.dto.user.UserBriefInformationResponseDto;
@@ -254,6 +255,30 @@ class UserServiceTest {
         assertEquals(profileInformationResponseDto.getEmail(), user.getEmail());
         assertEquals(profileInformationResponseDto.getNickname(), user.getNickname());
 
+    }
+
+    @Test
+    void getFullUserInformation() {
+
+        User user = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        user.setRequestFields(
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(user);
+
+        FullUserInformationResponse fullUserInformationResponse = userService.getFullUserInformation(user.getUsername());
+
+        assertEquals(fullUserInformationResponse.getPhoneNumber(), user.getPhoneNumber());
+        assertEquals(fullUserInformationResponse.getRealName(), user.getRealName());
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #99 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항z
<!-- 구체적으로 작성 부탁드립니다. -->
기존 회원 정보를 수정하기 위해, 휴대폰 번호와 실명 등을 제공해야 합니다. 

기존 API들은 디테일한 개인정보를 빼고, 모두 간소화된 유저의 정보를 제공했기에, 새로운 API를 만들었습니다.