### PR TITLE
Refactor: 108 reset bidirectional relationship between post like and post

### DIFF
--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -40,6 +40,9 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy="post")
     private List<Media> mediaList = new ArrayList<Media>();
 
+    @OneToMany(mappedBy="post")
+    private List<PostLike> postLikeList = new ArrayList<PostLike>();
+
     @OneToMany(mappedBy = "post")
     private List<Purchase> buyerList = new ArrayList<Purchase>();
 

--- a/src/main/java/com/dope/breaking/domain/post/PostLike.java
+++ b/src/main/java/com/dope/breaking/domain/post/PostLike.java
@@ -3,6 +3,7 @@ package com.dope.breaking.domain.post;
 import com.dope.breaking.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -10,6 +11,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class PostLike {
 
     @Id

--- a/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
@@ -39,9 +39,14 @@ class PostLikeServiceTest {
         postLikeService.likePost(user,post1);
         postLikeService.likePost(user,post2);
 
+        entityManager.flush();
+        entityManager.clear();
+
         //Then
         Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post1)).isTrue();
         Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post2)).isTrue();
+        Assertions.assertThat(postRepository.findById(post1.getId()).get().getPostLikeList().size()).isEqualTo(1);
+
 
     }
 
@@ -57,11 +62,18 @@ class PostLikeServiceTest {
 
         postLikeService.likePost(user,post);
 
+        entityManager.flush();
+        entityManager.clear();
+
         //When
         postLikeService.unlikePost(user,post);
 
+        entityManager.flush();
+        entityManager.clear();
+
         //Then
         Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post)).isFalse();
+        Assertions.assertThat(postRepository.findById(post.getId()).get().getPostLikeList().size()).isEqualTo(0);
 
     }
 
@@ -82,10 +94,13 @@ class PostLikeServiceTest {
 
         //When
         userRepository.delete(user);
+
         entityManager.flush();
+        entityManager.clear();
 
         //Then
         Assertions.assertThat(postLikeRepository.countPostLikesByUser(user)).isEqualTo(0);
+        Assertions.assertThat(postRepository.findById(post1.getId()).get().getPostLikeList().size()).isEqualTo(0);
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #108 

## 예상 리뷰 시간
2-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- Post 엔티티에 postLikeList를 설정하여 단방향 관계를 양방향으로 바꾸었습니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 트랜잭션과 영속성에 대해 공부하게 되었습니다. 앞으로는 헷갈리지 않고 사용할 수 있을 것 같네요.
- 추후 follow관련 기능도 이에 맞춰 리펙토링을 해보겠습니다.