### PR TITLE
refactor: refactor profile image compression logic

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -1,7 +1,6 @@
 package com.dope.breaking.api;
 
 import com.dope.breaking.dto.user.*;
-import com.dope.breaking.security.jwt.JwtTokenProvider;
 import com.dope.breaking.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -46,7 +45,7 @@ public class UserAPI {
     @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(
             @RequestPart String signUpRequest,
-            @RequestPart (required = false) List<MultipartFile> profileImg) {
+            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
         return userService.signUp(signUpRequest, profileImg);
     }
 

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -45,7 +45,7 @@ public class UserAPI {
     @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(
             @RequestPart String signUpRequest,
-            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
+            @RequestPart (required = false) List<MultipartFile> profileImg) {
         return userService.signUp(signUpRequest, profileImg);
     }
 
@@ -61,7 +61,7 @@ public class UserAPI {
     public ResponseEntity<?> profileUpdateConfirm(
             Principal principal,
             @RequestPart String updateRequest,
-            @RequestPart (required = false) List<MultipartFile> profileImg) throws Exception {
+            @RequestPart (required = false) List<MultipartFile> profileImg) {
 
         userService.updateProfile(principal.getName(), updateRequest, profileImg);
         return ResponseEntity.status(HttpStatus.CREATED).build();

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -3,7 +3,6 @@ package com.dope.breaking.domain.user;
 import com.dope.breaking.domain.financial.Purchase;
 import com.dope.breaking.domain.financial.Statement;
 import com.dope.breaking.domain.post.Post;
-import com.dope.breaking.domain.post.PostLike;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -77,16 +76,19 @@ public class User {
 
     private int balance;
 
-    private String profileImgURL;
+    private String originalProfileImgURL;
+
+    private String compressedProfileImgURL;
 
     @Column(length = 1000)
     private String refreshToken;
 
 
-    public void setRequestFields (String generatedImgURL, String nickname, String phoneNumber, String email,
+    public void setRequestFields (String originalProfileImgURL, String compressedProfileImgURL, String nickname, String phoneNumber, String email,
              String realName, String statusMsg, String username, Role role) {
 
-        this.profileImgURL = generatedImgURL;
+        this.originalProfileImgURL = originalProfileImgURL;
+        this.compressedProfileImgURL = compressedProfileImgURL;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.email = email;

--- a/src/main/java/com/dope/breaking/service/FollowService.java
+++ b/src/main/java/com/dope/breaking/service/FollowService.java
@@ -110,7 +110,7 @@ public class FollowService {
 
         for (Follow follow : followingList) {
             User followedUser = follow.getFollowed();
-            forListInfoResponseDtoList.add (new ForListInfoResponseDto(followedUser.getId(),followedUser.getNickname(),followedUser.getStatusMsg(),followedUser.getProfileImgURL()));
+            forListInfoResponseDtoList.add (new ForListInfoResponseDto(followedUser.getId(),followedUser.getNickname(),followedUser.getStatusMsg(),followedUser.getOriginalProfileImgURL()));
         }
 
         return forListInfoResponseDtoList;
@@ -126,7 +126,7 @@ public class FollowService {
 
         for (Follow follow : followerList) {
             User followedUser = follow.getFollowing();
-            forListInfoResponseDtoList.add(new ForListInfoResponseDto(followedUser.getId(),followedUser.getNickname(),followedUser.getStatusMsg(),followedUser.getProfileImgURL()));
+            forListInfoResponseDtoList.add(new ForListInfoResponseDto(followedUser.getId(),followedUser.getNickname(),followedUser.getStatusMsg(),followedUser.getOriginalProfileImgURL()));
         }
 
         return forListInfoResponseDtoList;

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -181,6 +181,37 @@ public class MediaService {
         return preMediaURL;
     }
 
+    public String compressImage(String originalProfileImgURL, double compressScale) throws Exception {
+
+        String fullPath = MAIN_DIR_NAME + originalProfileImgURL;
+        File originalMediaPath = new File(fullPath);
+        String compressedProfileImgFolderName = SUB_DIR_NAME + UploadType.COMPRESSED_PROFILE_IMG.getDirName();
+        File compressedProfileImgFolder = new File(MAIN_DIR_NAME + compressedProfileImgFolderName);
+
+        if(!compressedProfileImgFolder.exists()){compressedProfileImgFolder.mkdirs();}
+
+        String extension = originalProfileImgURL.substring(originalProfileImgURL.lastIndexOf(".") + 1);
+        MediaType mediaType = findMediaType(extension);
+
+        String compressedImageURL = compressedProfileImgFolderName + File.separator + UUID.randomUUID().toString() + "." + extension;
+        File destination = new File(MAIN_DIR_NAME + compressedImageURL);
+
+        BufferedImage oImage = ImageIO.read(originalMediaPath);
+
+        int compressedWidth = (int)Math.round(oImage.getWidth() * compressScale);
+        int compressedHeight = (int)Math.round(oImage.getHeight() * compressScale);
+
+        BufferedImage tImage = new BufferedImage(compressedWidth,compressedHeight, BufferedImage.TYPE_3BYTE_BGR);
+
+        Graphics2D graphic = tImage.createGraphics();
+        Image image = oImage.getScaledInstance(compressedWidth,compressedHeight,Image.SCALE_SMOOTH);
+        graphic.drawImage(image,0,0,compressedWidth,compressedHeight,null);
+        graphic.dispose();
+        ImageIO.write(tImage,extension,destination);
+
+        return compressedImageURL;
+    }
+
     public String makeThumbnail(String mediaUrl) throws IOException, JCodecException { //파일 주소를 받는다.
         String FullPath = MAIN_DIR_NAME + mediaUrl;
         File originalMediaPath = new File(FullPath); //전체 주소 경로를 받음

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -180,7 +180,7 @@ public class MediaService {
         return preMediaURL;
     }
 
-    public String compressImage(String originalProfileImgURL) throws Exception {
+    public String compressImage(String originalProfileImgURL) {
 
         String fullPath = MAIN_DIR_NAME + originalProfileImgURL;
         File originalMediaPath = new File(fullPath);
@@ -195,7 +195,12 @@ public class MediaService {
         String compressedImageURL = compressedProfileImgFolderName + File.separator + UUID.randomUUID().toString() + "." + extension;
         File destination = new File(MAIN_DIR_NAME + compressedImageURL);
 
-        BufferedImage oImage = ImageIO.read(originalMediaPath);
+        BufferedImage oImage = null;
+        try {
+            oImage = ImageIO.read(originalMediaPath);
+        } catch (IOException e) {
+            throw new CustomInternalErrorException(e.getMessage());
+        }
 
         int width = oImage.getWidth();
         int height = oImage.getHeight();
@@ -217,7 +222,11 @@ public class MediaService {
         Image image = oImage.getScaledInstance(width,height,Image.SCALE_SMOOTH);
         graphic.drawImage(image,0,0,width,height,null);
         graphic.dispose();
-        ImageIO.write(tImage,extension,destination);
+        try {
+            ImageIO.write(tImage,extension,destination);
+        } catch (IOException e) {
+            throw new CustomInternalErrorException(e.getMessage());
+        }
 
         return compressedImageURL;
     }

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -41,7 +41,6 @@ import java.util.List;
 public class MediaService {
 
     private final MediaRepository mediaRepository;
-
     private final PostRepository postRepository;
 
     private final String MAIN_DIR_NAME = System.getProperty("user.dir") + "/src/main/resources";
@@ -181,7 +180,7 @@ public class MediaService {
         return preMediaURL;
     }
 
-    public String compressImage(String originalProfileImgURL, double compressScale) throws Exception {
+    public String compressImage(String originalProfileImgURL) throws Exception {
 
         String fullPath = MAIN_DIR_NAME + originalProfileImgURL;
         File originalMediaPath = new File(fullPath);
@@ -198,14 +197,25 @@ public class MediaService {
 
         BufferedImage oImage = ImageIO.read(originalMediaPath);
 
-        int compressedWidth = (int)Math.round(oImage.getWidth() * compressScale);
-        int compressedHeight = (int)Math.round(oImage.getHeight() * compressScale);
+        int width = oImage.getWidth();
+        int height = oImage.getHeight();
 
-        BufferedImage tImage = new BufferedImage(compressedWidth,compressedHeight, BufferedImage.TYPE_3BYTE_BGR);
+        if (Math.min(width,height)>=500){
+            if(width<height){
+                width = 500;
+                height = Math.round(height*500/width);
+            }
+            else{
+                width = Math.round(width*500/height);
+                height = 500;
+            }
+        }
+        
+        BufferedImage tImage = new BufferedImage(width,height, BufferedImage.TYPE_3BYTE_BGR);
 
         Graphics2D graphic = tImage.createGraphics();
-        Image image = oImage.getScaledInstance(compressedWidth,compressedHeight,Image.SCALE_SMOOTH);
-        graphic.drawImage(image,0,0,compressedWidth,compressedHeight,null);
+        Image image = oImage.getScaledInstance(width,height,Image.SCALE_SMOOTH);
+        graphic.drawImage(image,0,0,width,height,null);
         graphic.dispose();
         ImageIO.write(tImage,extension,destination);
 

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -95,7 +95,7 @@ public class Oauth2LoginService {
             UserBriefInformationResponseDto userBriefInformationResponseDto  = UserBriefInformationResponseDto.builder()
                     .userId(user.getId())
                     .nickname(user.getNickname())
-                    .profileImgURL(user.getProfileImgURL())
+                    .profileImgURL(user.getOriginalProfileImgURL())
                     .balance(user.getBalance())
                     .build();
             return new ResponseEntity<UserBriefInformationResponseDto>(userBriefInformationResponseDto, httpHeaders, HttpStatus.OK);
@@ -169,7 +169,7 @@ public class Oauth2LoginService {
                     .userId(user.getId())
                     .balance(user.getBalance())
                     .nickname(user.getNickname())
-                    .profileImgURL(user.getProfileImgURL())
+                    .profileImgURL(user.getOriginalProfileImgURL())
                     .build();
             return new ResponseEntity<UserBriefInformationResponseDto>(userBriefInformationResponseDto, httpHeaders, HttpStatus.OK);
         }

--- a/src/main/java/com/dope/breaking/service/PostLikeService.java
+++ b/src/main/java/com/dope/breaking/service/PostLikeService.java
@@ -78,7 +78,7 @@ public class PostLikeService {
         List<ForListInfoResponseDto> forListInfoResponseDtoList = new ArrayList<>();
         for (PostLike postLike : postLikeList) {
             User user = postLike.getUser();
-            forListInfoResponseDtoList.add(new ForListInfoResponseDto(user.getId(),user.getNickname(),user.getStatusMsg(),user.getProfileImgURL()));
+            forListInfoResponseDtoList.add(new ForListInfoResponseDto(user.getId(),user.getNickname(),user.getStatusMsg(),user.getOriginalProfileImgURL()));
         }
         return forListInfoResponseDtoList;
     }

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -164,7 +164,7 @@ public class PostService {
         WriterDto writerDto = WriterDto.builder()
                 .nickname(post.getUser().getNickname())
                 .phoneNumber(post.getUser().getPhoneNumber())
-                .profileImgURL(post.getUser().getProfileImgURL())
+                .profileImgURL(post.getUser().getOriginalProfileImgURL())
                 .userId(post.getUser().getId()).build();
 
         LocationDto locationDto = LocationDto.builder()

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -78,7 +78,7 @@ public class UserService {
                 .balance(user.getBalance())
                 .userId(user.getId())
                 .nickname(user.getNickname())
-                .profileImgURL(user.getProfileImgURL())
+                .profileImgURL(user.getOriginalProfileImgURL())
                 .build();
 
         return new ResponseEntity<UserBriefInformationResponseDto>(userBriefInformationResponseDto, httpHeaders, HttpStatus.CREATED);
@@ -95,7 +95,7 @@ public class UserService {
         // 5. update profile
 
         String profileImgFileName = mediaService.getBasicProfileDir();
-        String originalProfileUrl = user.getProfileImgURL();
+        String originalProfileUrl = user.getOriginalProfileImgURL();
 
         // case 1: 기본 이미지 -> 기본 이미지 : 변경 없음
 
@@ -136,7 +136,7 @@ public class UserService {
     public UserBriefInformationResponseDto userBriefInformation(String username) {
 
         User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
-        return new UserBriefInformationResponseDto(user.getProfileImgURL(), user.getNickname(), user.getId(), user.getBalance());
+        return new UserBriefInformationResponseDto(user.getOriginalProfileImgURL(), user.getNickname(), user.getId(), user.getBalance());
     }
 
     private SignUpRequestDto transformUserInformationToObject(String signUpRequest) {
@@ -294,7 +294,7 @@ public class UserService {
 
         return ProfileInformationResponseDto.builder()
                 .userId(user.getId())
-                .profileImgURL(user.getProfileImgURL())
+                .profileImgURL(user.getOriginalProfileImgURL())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .statusMsg(user.getStatusMsg())
@@ -315,7 +315,7 @@ public class UserService {
                 .realName(user.getRealName())
                 .role(user.getRole())
                 .statusMsg(user.getStatusMsg())
-                .profileImgURL(user.getProfileImgURL())
+                .profileImgURL(user.getOriginalProfileImgURL())
                 .build();
     }
 }

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -43,7 +43,7 @@ public class UserService {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public ResponseEntity<?> signUp(String signUpRequest, List<MultipartFile> profileImg) throws Exception {
+    public ResponseEntity<?> signUp(String signUpRequest, List<MultipartFile> profileImg) {
 
         SignUpRequestDto signUpRequestDto = transformUserInformationToObject(signUpRequest);
 
@@ -88,7 +88,7 @@ public class UserService {
         return new ResponseEntity<UserBriefInformationResponseDto>(userBriefInformationResponseDto, httpHeaders, HttpStatus.CREATED);
     }
 
-    public void updateProfile(String username, String updateRequestDto, List<MultipartFile> profileImg) throws Exception {
+    public void updateProfile(String username, String updateRequestDto, List<MultipartFile> profileImg) {
 
         User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
 

--- a/src/test/java/com/dope/breaking/api/RelationshipAPITest.java
+++ b/src/test/java/com/dope/breaking/api/RelationshipAPITest.java
@@ -84,7 +84,7 @@ class RelationshipAPITest {
 
         //Then
         Assertions.assertThat(followedUser.getFollowerList().size()).isEqualTo(1);
-        Assertions.assertThat(userRepository.findById(1L).get().getFollowingList().size()).isEqualTo(1);
+        Assertions.assertThat(userRepository.findByUsername("12345g").get().getFollowingList().size()).isEqualTo(1);
 
     }
 

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
 
@@ -22,6 +23,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@Transactional
 class UserAPITest {
 
     @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -34,6 +34,7 @@ class UserAPITest {
                 ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -57,6 +58,7 @@ class UserAPITest {
         SignUpRequestDto signUpRequest =  new SignUpRequestDto
                 ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
         user.setRequestFields(
+                "anyURL",
                 "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -33,6 +33,7 @@ class FollowRepositoryTest {
                 ("statusMsg","hero","phoneNumber","test@email.com","realname","testUsername", "press");
         hero.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -48,6 +49,7 @@ class FollowRepositoryTest {
                 ("statusMsg","follower1","phoneNumber","test@email.com","realname","testUsername", "press");
         follower1.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest2.getNickname(),
                 signUpRequest2.getPhoneNumber(),
                 signUpRequest2.getEmail(),
@@ -62,6 +64,7 @@ class FollowRepositoryTest {
         SignUpRequestDto signUpRequest3 =  new SignUpRequestDto
                 ("statusMsg","follower2","phoneNumber","test@email.com","realname","testUsername", "press");
         follower2.setRequestFields(
+                "anyURL",
                 "anyURL",
                 signUpRequest3.getNickname(),
                 signUpRequest3.getPhoneNumber(),

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -21,7 +21,7 @@ class UserRepositoryTest {
 
         //Given
         User user = new User();
-        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
 
         //When
         User savedUser = userRepository.save(user);
@@ -53,7 +53,7 @@ class UserRepositoryTest {
 
         //Given
         User user = new User();
-        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
 
         //When
         User savedUser = userRepository.save(user);

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -162,7 +162,7 @@ class UserServiceTest {
         //Then
         assertEquals(foundUserInfo.getUserId(), user.getId());
         assertEquals(foundUserInfo.getNickname(), user.getNickname());
-        assertEquals(foundUserInfo.getProfileImgURL(), user.getProfileImgURL());
+        assertEquals(foundUserInfo.getProfileImgURL(), user.getOriginalProfileImgURL());
     }
 
     @Test

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -76,6 +76,7 @@ class UserServiceTest {
         User user = new User();
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -146,6 +147,7 @@ class UserServiceTest {
                 ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","testUsername", "press");
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -174,6 +176,7 @@ class UserServiceTest {
                 ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","testUsername", "press");
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -200,6 +203,7 @@ class UserServiceTest {
                 ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","testUsername", "press");
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -214,6 +218,7 @@ class UserServiceTest {
         SignUpRequestDto anotherSignUpRequest =  new SignUpRequestDto
                 ("statusMsg","nickname","phoneNumber","mwk300@nyu.edu","realname","anotherTestUsername", "press");
         anotherUser.setRequestFields(
+                "anyURL",
                 "anyURL",
                 anotherSignUpRequest.getNickname(),
                 anotherSignUpRequest.getPhoneNumber(),
@@ -240,6 +245,7 @@ class UserServiceTest {
                 ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
         user.setRequestFields(
                 "anyURL",
+                "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),
                 signUpRequest.getEmail(),
@@ -264,6 +270,7 @@ class UserServiceTest {
         SignUpRequestDto signUpRequest =  new SignUpRequestDto
                 ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
         user.setRequestFields(
+                "anyURL",
                 "anyURL",
                 signUpRequest.getNickname(),
                 signUpRequest.getPhoneNumber(),


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #106 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- User entity에 "profileImg" 필드를 지우고 "originalProfileImg" 와 "compressedProfileImg"를 추가했습니다.
- 이에 맞게 User 빌더와 테스트코드까지 수정했습니다.
- 프로필 사진을 압축하는 기능을 구현했습니다.
   - 가로와 세로 중 더 작은 값이 500보다 작을 경우 압축하지 않습니다.
   - 가로와 세로 중 더 작은 값이 500보다 클 경우:
       1. 가로와 세로 중 더 작은 값을 500으로 고정합니다.
       2. 가로와 세로 중 더 큰 값의 길이의 비율을 고정하여 줄입니다.

- 프로필 수정 요청시에만 원본 url을 담아보내며, 나머지 상황에는 모두 압축된 사진의 url을 보내는 방식으로 구현했습니다. 

- 테스트 수정: RelationshipAPI와 UserAPI의 수정했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

 @JinuCheon 아래와 같이 피드 관련 테스트가 돌아가지 않습니다. 아마 제가 프로필 사진 관련 필드를 변경해서 생긴 문제일겁니다. 
 변경사항에 맞춰 수정 부탁드리겠습니다. (제가 수정해보려 했다가, 함부로 건드리면 또 일 날 것 같아 부탁드립니다ㅜㅜ)

<img width="1232" alt="스크린샷 2022-07-21 오전 12 05 31" src="https://user-images.githubusercontent.com/87322089/180020233-9ddb08c6-784b-408e-81bf-b7165bbfe643.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
