### PR TITLE
fix: duplicated information error when update user

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -21,23 +21,35 @@ public class UserAPI {
 
 
     @GetMapping("/oauth2/sign-up/validate-phone-number/{phoneNumber}")
-    public ResponseEntity<Void> validatePhoneNumber(@PathVariable String phoneNumber){
+    public ResponseEntity<Void> validatePhoneNumber(@PathVariable String phoneNumber, Principal principal){
 
-        userService.validatePhoneNumber(phoneNumber);
+        String username = null;
+        if(principal != null)  {
+            username = principal.getName();
+        }
+        userService.validatePhoneNumber(phoneNumber, username);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/oauth2/sign-up/validate-email/{email}")
-    public ResponseEntity<Void> validateEmail(@PathVariable String email){
+    public ResponseEntity<Void> validateEmail(@PathVariable String email, Principal principal){
 
-        userService.validateEmail(email);
+        String username = null;
+        if(principal != null)  {
+            username = principal.getName();
+        }
+        userService.validateEmail(email, username);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/oauth2/sign-up/validate-nickname/{nickname}")
-    public ResponseEntity<Void> validateNickname(@PathVariable String nickname){
+    public ResponseEntity<Void> validateNickname(@PathVariable String nickname, Principal principal){
 
-        userService.validateNickname(nickname);
+        String username = null;
+        if(principal != null)  {
+            username = principal.getName();
+        }
+        userService.validateNickname(nickname, username);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
@@ -64,7 +64,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         post.isSold,
                         post.viewCount,
                         user.id,
-                        user.profileImgURL,
+                        user.compressedProfileImgURL,
                         user.realName,
                         post.price,
                         Expressions.asBoolean(false),

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -197,9 +197,9 @@ public class UserService {
             throw new MissingFormatArgumentException(String.valueOf(violation.getPropertyPath()));
         }
 
-        validatePhoneNumber(signUpRequestDto.getPhoneNumber());
-        validateEmail(signUpRequestDto.getEmail());
-        validateNickname(signUpRequestDto.getNickname());
+        validatePhoneNumber(signUpRequestDto.getPhoneNumber(), null);
+        validateEmail(signUpRequestDto.getEmail(), null);
+        validateNickname(signUpRequestDto.getNickname(), null);
         validateRole(signUpRequestDto.getRole());
 
     }
@@ -225,20 +225,21 @@ public class UserService {
             throw new NotValidRequestBodyException(result.toString());
         }
 
-        if (!updateUserRequestDto.getPhoneNumber().equals(preUserInformation.getPhoneNumber())) {
-            validatePhoneNumber(updateUserRequestDto.getPhoneNumber());
-        }
-        if (!updateUserRequestDto.getEmail().equals(preUserInformation.getEmail())) {
-            validateEmail(updateUserRequestDto.getEmail());
-        }
-        if (!updateUserRequestDto.getNickname().equals(preUserInformation.getNickname())) {
-            validateNickname(updateUserRequestDto.getNickname());
-        }
+        validatePhoneNumber(updateUserRequestDto.getPhoneNumber(), preUserInformation.getUsername());
+        validateEmail(updateUserRequestDto.getEmail(), preUserInformation.getUsername());
+        validateNickname(updateUserRequestDto.getNickname(), preUserInformation.getUsername());
         validateRole(updateUserRequestDto.getRole());
 
     }
 
-    public void validatePhoneNumber(String phoneNumber) {
+    public void validatePhoneNumber(String phoneNumber, String username) {
+
+        if(username != null) {
+            String currentUserPhoneNumber = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new).getPhoneNumber();
+            if(currentUserPhoneNumber.equals(phoneNumber)) {
+                return;
+            }
+        }
 
         if (!Pattern.matches("^(\\d{11}|\\d{3}\\d{4}\\d{4})$", phoneNumber)) {
             throw new InvalidUserInformationFormatException(FailableUserInformation.PHONENUMBER);
@@ -250,7 +251,14 @@ public class UserService {
         }
     }
 
-    public void validateEmail(String email) {
+    public void validateEmail(String email, String username) {
+
+        if(username != null) {
+            String currentUserEmail = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new).getEmail();
+            if(currentUserEmail.equals(email)) {
+                return;
+            }
+        }
 
         if (!Pattern.matches("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$", email)) {
             throw new InvalidUserInformationFormatException(FailableUserInformation.EMAIL);
@@ -262,9 +270,16 @@ public class UserService {
         }
     }
 
-    public void validateNickname(String nickname) {
+    public void validateNickname(String nickname, String username) {
 
-        if (!Pattern.matches("^(?=.*[a-z0-9가-힣])[a-z0-9가-힣]{2,16}$", nickname)) {
+        if(username != null) {
+            String currentUserNickname = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new).getNickname();
+            if(currentUserNickname.equals(nickname)) {
+                return;
+            }
+        }
+
+        if (!Pattern.matches("^(?=.*[a-zA-Z0-9가-힣])[a-zA-Z0-9가-힣]{2,16}$", nickname)) {
             throw new InvalidUserInformationFormatException(FailableUserInformation.NICKNAME);
         }
 

--- a/src/test/java/com/dope/breaking/service/UserServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/UserServiceTest.java
@@ -7,7 +7,11 @@ import com.dope.breaking.dto.user.ProfileInformationResponseDto;
 import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.dto.user.UserBriefInformationResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.user.DuplicatedUserInformationException;
+import com.dope.breaking.exception.user.InvalidUserInformationFormatException;
 import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,44 +30,11 @@ class UserServiceTest {
     @Autowired UserRepository userRepository;
     @Autowired EntityManager em;
 
-//    @Test
-//    void isValidEmailFormat() {
-//
-//        String email1 = "hello@naver.com";
-//        String email2 = "hello@naver";
-//        String email3 = "hello";
-//
-//        assertTrue(userService.isValidEmailFormat(email1));
-//        assertFalse(userService.isValidEmailFormat(email2));
-//        assertFalse(userService.isValidEmailFormat(email3));
-//
-//    }
-//
-//    @Test
-//    void isValidPhoneNumberFormat() {
-//
-//        String number1 = "01012345678";
-//        String number2 = "0212345678";
-//        String number3 = "010102312";
-//
-//        assertTrue(userService.isValidPhoneNumberFormat(number1));
-//        assertTrue(userService.isValidPhoneNumberFormat(number2));
-//        assertFalse(userService.isValidPhoneNumberFormat(number3));
-//
-//    }
-//
-//    @Test
-//    void isValidRole() {
-//
-//        String role1 = "PRESS";
-//        String role2 = "PreSs";
-//        String role3 = "Pre";
-//
-//        assertTrue(userService.isValidRole(role1));
-//        assertTrue(userService.isValidRole(role2));
-//        assertFalse(userService.isValidRole(role3));
-//
-//    }
+
+    @Test
+    void validateNickname() {
+
+    }
 
     @Test
     void signUpConfirm() {
@@ -286,6 +257,128 @@ class UserServiceTest {
 
         assertEquals(fullUserInformationResponse.getPhoneNumber(), user.getPhoneNumber());
         assertEquals(fullUserInformationResponse.getRealName(), user.getRealName());
+    }
+
+    @DisplayName("휴대폰 번호 형식이 잘못되었을 경우, 예외가 발생한다.")
+    @Test()
+    void validateUserPhoneNumber() {
+
+        userService.validatePhoneNumber("01026695282", null);
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validatePhoneNumber("0102669528", null));
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validatePhoneNumber("010-2669-5282", null));
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validatePhoneNumber("aaaaaaaaaaa", null));
+    }
+
+    @DisplayName("휴대폰 번호 중복이 있을 경우, 예외가 발생한다.")
+    @Test
+    void duplicatedUserPhoneNumberFailure() {
+
+        User oldUser = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","01026695282","test@email.com","realname","testUsername", "press");
+        oldUser.setRequestFields(
+                "anyURL",
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(oldUser);
+        Assertions.assertThrows(DuplicatedUserInformationException.class, () -> userService.validatePhoneNumber(oldUser.getPhoneNumber(), null));
+    }
+
+    @DisplayName("이메일 형식이 잘못되었을 경우, 예외가 발생한다.")
+    @Test
+    void validateUserEmail() {
+
+        userService.validateEmail("woojin8787@gmail.com", null);
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validateEmail("woojin8787", null));
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validateEmail("woojin8787gmail.com", null));
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validateEmail("woojin8787@gmail", null));
+    }
+
+    @DisplayName("이메일 중복이 있을 경우, 예외가 발생한다.")
+    @Test
+    void duplicatedUserEmailFailure() {
+
+        User oldUser = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","01026695282","test@email.com","realname","testUsername", "press");
+        oldUser.setRequestFields(
+                "anyURL",
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(oldUser);
+        Assertions.assertThrows(DuplicatedUserInformationException.class, () -> userService.validateEmail(oldUser.getEmail(), null));
+    }
+
+    @DisplayName("닉네임 형식이 잘못되었을 경우, 예외가 발생한다.")
+    @Test
+    void validateUserNicknameFormat() {
+
+        userService.validateNickname("AbCdEf", null);
+        userService.validateNickname("abc123", null);
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validateNickname("@ABC", null));
+        Assertions.assertThrows(InvalidUserInformationFormatException.class, () -> userService.validateNickname("b", null));
+    }
+
+    @DisplayName("휴대폰 번호 중복이 있을 경우, 예외가 발생한다.")
+    @Test
+    void duplicatedUserNicknameFailure() {
+
+        User oldUser = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","phoneNumber","test@email.com","realname","testUsername", "press");
+        oldUser.setRequestFields(
+                "anyURL",
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+        userRepository.save(oldUser);
+        Assertions.assertThrows(DuplicatedUserInformationException.class, () -> userService.validateNickname(oldUser.getNickname(), null));
+    }
+
+    @DisplayName("회원 수정에서, 기존 회원이 같은 정보를 입력하면 중복 예외가 발생하지 않는다.")
+    @Test
+    void validateWhenCurrentUserUpdateProfileWithSameInformation() {
+
+        User currentUser = new User();
+        SignUpRequestDto signUpRequest =  new SignUpRequestDto
+                ("statusMsg","nickname","01026695282","test@email.com","realname","testUsername", "press");
+        currentUser.setRequestFields(
+                "anyURL",
+                "anyURL",
+                signUpRequest.getNickname(),
+                signUpRequest.getPhoneNumber(),
+                signUpRequest.getEmail(),
+                signUpRequest.getRealName(),
+                signUpRequest.getStatusMsg(),
+                signUpRequest.getUsername(),
+                Role.valueOf(signUpRequest.getRole().toUpperCase(Locale.ROOT))
+        );
+
+        userRepository.save(currentUser);
+
+        userService.validatePhoneNumber(currentUser.getPhoneNumber(), currentUser.getUsername());
+        userService.validateEmail(currentUser.getEmail(), currentUser.getUsername());
+        userService.validateNickname(currentUser.getNickname(), currentUser.getUsername());
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #113 


## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
회원이 유저 정보 변경을 하는 경우, 기존 정보가 중복 정보로 예외처리 되는 경우가 있었습니다.

개별 validate API 에서 이 문제가 발생하는 경우를 처리하지 않아서 발생한 문제였습니다.

그리고 기존에 리팩토링 하면서 삭제했던 validate 관련된 테스트 코드를 다시 보완해서 작성했습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

이제부터 테스트 코드 작성 시에, @Display 를 사용하여 description을 적어주세요.

형식은 **"어떠한 경우, 이렇게 된다. "** 이런식으로 이슈 제목과 비슷한 느낌으로 통일해서 작성해주시면 감사하겠습니다. 
기존 코드들은 조금씩 수정해나가겠습니다.
![image](https://user-images.githubusercontent.com/76773202/180354069-607c83bd-767f-4d51-81fb-ec1cd753e411.png)
