### PR TITLE
fix: fixed a bug where is is-prefix were omitted in  response of postRead function

### DIFF
--- a/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.dto.post;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,12 +16,12 @@ import java.util.List;
 @Getter
 @Setter
 public class DetailPostResponseDto {
-    private boolean hasLiked; //현재 접속한 유저는 좋아요를 눌렀는가에 대한 판별
+	private boolean hasLiked; //현재 접속한 유저는 좋아요를 눌렀는가에 대한 판별
 
 	private WriterDto user;
 
 	private String title;
-    private String content;
+	private String content;
 	private List<String> hashtagList = new LinkedList<>();
 
 	private List<String> mediaList = new LinkedList<>();
@@ -30,6 +32,7 @@ public class DetailPostResponseDto {
 
 	private String postType;//exclusive, public, free
 
+	@JsonProperty(value = "isAnonymous")
 	private boolean isAnonymous;
 
 	private LocalDateTime eventTime;
@@ -42,10 +45,12 @@ public class DetailPostResponseDto {
 
 	private int shareCount;
 
+	@JsonProperty(value = "isSold")
 	private boolean isSold;
 
 	private int soldCount;
 
+	@JsonProperty(value = "isHidden")
 	private boolean isHidden;
 
 	@Builder
@@ -66,3 +71,4 @@ public class DetailPostResponseDto {
 		this.viewCount = viewCount;
 	}
 }
+


### PR DESCRIPTION

## 관련 이슈
<!-- close #이슈번호 -->
close #121 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
게시글 조회에서 is- 접두사가 붙은 필드들의 key값에서 is-접두사가 생략되어 반환하는 버그를 발견하여 @JsonProperty어노테이션을 붙여줌으로써 생략되지 않도록 조치하였습니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
없음.
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
클라이언트와의 규약을 맞추기 위해 급히 수정합니다!