### PR TITLE
feat: Implement the function to delete posts

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -50,4 +50,12 @@ public class PostAPI {
         }
         return new ResponseEntity<DetailPostResponseDto>(postService.read(postId, crntUsername), HttpStatus.OK);
     }
+
+
+    @PreAuthorize("isAuthenticated()")
+    @DeleteMapping("/post/{postId}")
+    public ResponseEntity postDelete(@PathVariable("postId") long postId, Principal principal){
+        return postService.delete(postId, principal.getName());
+    }
+
 }

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -47,10 +47,10 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<PostCommentHashtag> postCommentHashtags = new ArrayList<PostCommentHashtag>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Purchase> buyerList = new ArrayList<Purchase>();
 
-    @OneToMany(mappedBy = "post")
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarkList = new ArrayList<Bookmark>();
 
 

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -29,6 +29,8 @@ public enum ErrorCode {
     ALREADY_UNFOLLOWING("BSE421","이미 언팔로우 중인 유저입니다."),
     NO_SUCH_POST("BSE450","해당 제보를 찾을 수 없습니다"),
     NO_SUCH_COMMENT("BSE451","해당 댓글을 찾을 수 없습니다"),
+
+    PURCHASED_POST("BSE452", "판매된 게시글은 삭제할 수 없습니다."),
     ALREADY_LIKED("BSE458","이미 좋아요를 선택했습니다."),
     ALREADY_UNLIKED("BSE459","이미 좋아요를 선택하지 않았습니다."),
 

--- a/src/main/java/com/dope/breaking/exception/post/PurchasedPostException.java
+++ b/src/main/java/com/dope/breaking/exception/post/PurchasedPostException.java
@@ -1,0 +1,13 @@
+package com.dope.breaking.exception.post;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class PurchasedPostException extends BreakingException {
+
+    public PurchasedPostException(){
+        super(ErrorCode.PURCHASED_POST, HttpStatus.NOT_ACCEPTABLE);
+
+    }
+}

--- a/src/main/java/com/dope/breaking/repository/PostRepository.java
+++ b/src/main/java/com/dope/breaking/repository/PostRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostRepository extends JpaRepository<Post,Long> {
     Boolean existsByIdAndUserId(Long postid, Long userid);
+
+
 }

--- a/src/main/java/com/dope/breaking/repository/PurchaseRepository.java
+++ b/src/main/java/com/dope/breaking/repository/PurchaseRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
     int countByPost(Post post);
+
+    boolean existsByPost(Post post);
 }

--- a/src/main/java/com/dope/breaking/service/PostCommentHashtagService.java
+++ b/src/main/java/com/dope/breaking/service/PostCommentHashtagService.java
@@ -28,7 +28,7 @@ public class PostCommentHashtagService {
 
 
     @Transactional
-    public void savePostCommentHashtag(List<String> postHashtags, Long postId, HashtagType hashtagType){
+    public void savePostHashtag(List<String> postHashtags, Long postId, HashtagType hashtagType){
         Post post = postRepository.findById(postId).get();
 
         for(String hashtag : postHashtags){
@@ -50,7 +50,7 @@ public class PostCommentHashtagService {
     }
 
     @Transactional
-    public void modifyPostCommentHashtag(List<String> postHashtags, Post post, HashtagType hashtagType){
+    public void modifyPostHashtag(List<String> postHashtags, Post post, HashtagType hashtagType){
         postCommentHashtagRepository.deleteAllByPost(post);
         for(String hashtag : postHashtags){
             Hashtag hashtagEntity = new Hashtag();

--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -80,6 +80,7 @@ class PostAPITest {
 
     static Long postId;
 
+    @DisplayName("게시글을 저장하기위해, 유저를 등록한다.")
     @Order(1)
     @Test
     public void createUserInfo() {
@@ -92,7 +93,7 @@ class PostAPITest {
         userRepository.save(user);
     }
 
-    @DisplayName("POST 등록 테스트")
+    @DisplayName("게시글을 저장한다.")
     @Order(2)
     @WithMockCustomUser
     @Test
@@ -142,7 +143,7 @@ class PostAPITest {
     }
 
 
-    @DisplayName("POST 수정 테스트")
+    @DisplayName("게시글을 수정한다.")
     @Order(3)
     @WithMockCustomUser
     @Test
@@ -194,14 +195,11 @@ class PostAPITest {
         String content = response.getContentAsString();
     }
 
-
-    @DisplayName("POST 조회 기능")
+    @DisplayName("게시글을 조회힌다.")
     @WithMockCustomUser
     @Order(4)
     @Test
     public void readPostWithAnonymous() throws Exception {
-        //When
-
         MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.get("/post/" + postId))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isLiked").value(false))
@@ -212,6 +210,21 @@ class PostAPITest {
         System.out.println(content);
     }
 
+    @DisplayName("게시글을 삭제한다.")
+    @WithMockCustomUser
+    @Order(5)
+    @Test
+    public void deletePost() throws Exception{
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/" + postId))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
 
 
+        User user = userRepository.findByUsername("12345g").get();
+        userRepository.delete(user);
+    }
 }

--- a/src/test/java/com/dope/breaking/service/PostCommentHashtagServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostCommentHashtagServiceTest.java
@@ -35,7 +35,7 @@ class PostCommentHashtagServiceTest {
         hashtag.add("hello1");
         hashtag.add("hello2");
         //When
-        postCommentHashtagService.savePostCommentHashtag(hashtag, postId, HashtagType.POST);
+        postCommentHashtagService.savePostHashtag(hashtag, postId, HashtagType.POST);
 
         //Then
 
@@ -52,13 +52,13 @@ class PostCommentHashtagServiceTest {
         List<String> hashtag = new ArrayList<>();
         hashtag.add("hello1");
         hashtag.add("hello2");
-        postCommentHashtagService.savePostCommentHashtag(hashtag, postId, HashtagType.POST);
+        postCommentHashtagService.savePostHashtag(hashtag, postId, HashtagType.POST);
 
         //When
         hashtag.clear();
         hashtag.add("hello1");
         hashtag.add("hello3");
-        postCommentHashtagService.modifyPostCommentHashtag(hashtag, post, HashtagType.POST);
+        postCommentHashtagService.modifyPostHashtag(hashtag, post, HashtagType.POST);
 
         //Then
         Assertions.assertSame(postCommentHashtagRepository.findAllByPost(post).size(), 2);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #125 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 게시글 CRUD의 마지막 기능인 삭제 기능을 구현하였습니다. 
게시글 삭제 시 연관되어있는 엔티티 또한 모두 날아가게 하였으며, 저장되어있는 미디어 파일도 같이 디렉토리에서 삭제됩니다. 해시태그 또한 마찬가지로 아무 연관 맵핑이 되어있지 않은 상태라면 삭제하게 됩니다. 

2. hashtagService에서 메서드 명을 수정하였습니다. 게시글 등록시에만 사용가능하도록 구현한 메서드명이 PostComment라는 애매모호한 명이기에 목적에 맞게 사용하도록 Post만 명세하였습니다. 

3. 구매된 게시글은 숨김처리만 가능하기에, 이미 판매되었다면 에러를 반환합니다. "BSE452"

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="556" alt="스크린샷 2022-07-25 오후 1 30 10" src="https://user-images.githubusercontent.com/62254434/180699483-8835a825-1928-4be1-a06d-1483920bcf89.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
다음으로 북마크 기능을 구현하도록 하겠습니다. 