### PR TITLE
feat: refactor postModify function

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -2,6 +2,7 @@ package com.dope.breaking.api;
 
 
 import com.dope.breaking.dto.post.DetailPostResponseDto;
+import com.dope.breaking.dto.post.PostRequestDto;
 import com.dope.breaking.service.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,10 +33,9 @@ public class PostAPI {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PutMapping(value = "/post/{postId}", consumes = {"multipart/form-data"})
-    public ResponseEntity<Map<String, Long>> postModify(@PathVariable("postId") long postId, Principal principal,
-                                        @RequestPart(value = "mediaList", required = false) List<MultipartFile> files, @RequestPart(value = "data") String contentData) throws Exception {
-        postService.modify(postId, principal.getName(), contentData, files);
+    @PutMapping(value = "/post/{postId}")
+    public ResponseEntity<Map<String, Long>> postModify(@PathVariable("postId") long postId, Principal principal, @RequestBody PostRequestDto postRequestDto) throws Exception {
+        postService.modify(postId , principal.getName(), postRequestDto);
         Map<String, Long> result = new LinkedHashMap<>();
         result.put("Modified postId", postId);
         return ResponseEntity.status(HttpStatus.OK).body(result);

--- a/src/main/java/com/dope/breaking/dto/post/PostRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostRequestDto.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.dto.post;
 
+import com.dope.breaking.domain.post.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
@@ -12,7 +13,6 @@ import java.util.List;
 
 @ToString
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 public class PostRequestDto {
     @NotNull
@@ -40,4 +40,18 @@ public class PostRequestDto {
     private List<String> hashtagList;
 
     private int thumbnailIndex;
+
+
+    @Builder
+    public PostRequestDto(String title, String content, int price, Boolean isAnonymous, String postType, LocalDateTime eventTime, LocationDto locationDto, List<String> hashtagList, int thumbnailIndex) {
+        this.title = title;
+        this.content = content;
+        this.price = price;
+        this.isAnonymous = isAnonymous;
+        this.postType = postType;
+        this.eventTime = eventTime;
+        this.locationDto = locationDto;
+        this.hashtagList = hashtagList;
+        this.thumbnailIndex = thumbnailIndex;
+    }
 }

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -125,22 +125,6 @@ public class MediaService {
     }
 
 
-    @Transactional
-    public void modifyMediaEntities(List<String> preFileNameList, List<String> newFileNameList, Long postId) {
-        Post post = postRepository.findById(postId).get();
-
-        for (String m : preFileNameList) {
-            Media media = mediaRepository.findByPostIdAndMediaURL(postId, m);
-            mediaRepository.delete(media);
-        }
-
-        for (String fileName : newFileNameList) {
-            MediaType mediaType = findMediaType(fileName);
-            Media media = new Media(post, mediaType, fileName);
-            mediaRepository.save(media);
-        }
-    }
-
     public void deleteMedias(List<String> fileNames) {
         for (String fileName : fileNames) {
             File savedFile = new File(MAIN_DIR_NAME + fileName);
@@ -171,14 +155,6 @@ public class MediaService {
         }
     }
 
-    public List<String> preMediaURL(Long postId) {
-        List<Media> list = mediaRepository.findAllByPostId(postId);
-        List<String> preMediaURL = new LinkedList<>();
-        for (Media m : list) {
-            preMediaURL.add(m.getMediaURL());
-        }
-        return preMediaURL;
-    }
 
     public String compressImage(String originalProfileImgURL) {
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #139 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1.  기존에는 기존의 게시글을 수정하려 할 시, 내용 뿐만이 아니라, 영상/사진 또한 새로받아 수정해야 했습니다. 허나, 플랫폼 특성에 맞게 영상/사진은 수정이 불가능하며 내용만 수정 가능하도록 리팩토링 하였습니다. 이와 더불어 불필요한 메서드를 삭제하였습니다. 

2. 요청을 Json으로 받도록 하였습니다. 
 다만, validation의 경우 이미 구현해 놓은 메서드를 활용하여 커스텀 예외처리가 발동하도록 구현하였습니다. @Valid를 사용하여 기본 예외처리가 아닌, transferPostRequestToObject 메서드를 사용합니다. 



## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="666" alt="스크린샷 2022-07-25 오후 7 12 34" src="https://user-images.githubusercontent.com/62254434/180755427-e1261b0c-ec76-444f-a41f-0ba7ef717ac3.png">
<img width="707" alt="스크린샷 2022-07-25 오후 7 12 20" src="https://user-images.githubusercontent.com/62254434/180756094-c789d126-49a0-4a86-ac2b-b33695d4a6b3.png">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
다음으로 테스트코드 리팩토링을 진행하며 기존의 메서드와 유닛 테스트의 신뢰성과 안정성을 확보하도록 하겠습니다. 