### PR TITLE
refactor: change pagination strategy to cursor based

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,9 +27,9 @@ public class FeedAPI {
     private final SearchFeedService searchFeedService;
 
     @GetMapping("/feed")
-    public ResponseEntity<Page<FeedResultPostDto>> searchFeed(
-            @RequestParam(value="page") int page,
-            @RequestParam(value="size") int size,
+    public ResponseEntity<List<FeedResultPostDto>> searchFeed(
+            @RequestParam(value="cursor") Long cursor,
+            @RequestParam(value="size") Long size,
             @RequestParam(value="search", required = false) String searchKeyword,
             @RequestParam(value="sort", required = false) String sortStrategy,
             @RequestParam(value="sold-option", required = false, defaultValue = "ALL") String soldOption,
@@ -38,6 +39,8 @@ public class FeedAPI {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .searchKeyword(searchKeyword)
+                .cursorId(cursor)
+                .size(size)
                 .sortStrategy(SortStrategy.findMatchedEnum(sortStrategy))
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
                 .dateFrom(dateFrom)
@@ -46,8 +49,7 @@ public class FeedAPI {
                 .forLastMin(forLastMin)
                 .build();
 
-        Pageable pageable = PageRequest.of(page, size);
-        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto, pageable));
+        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto));
 
     }
 

--- a/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
@@ -22,7 +22,7 @@ public class FeedResultPostDto {
     private int viewCount;
     private Long userId;
     private String profileImgURL;
-    private String realName;
+    private String nickname;
     private int price;
     private Boolean isLiked;
     private Boolean isBookmarked;
@@ -31,7 +31,7 @@ public class FeedResultPostDto {
     @QueryProjection
     public FeedResultPostDto(Long postId, String title, String region, String thumbnailImgURL, int likeCount,
                              PostType postType, Boolean isSold, int viewCount, Long userId, String profileImgURL,
-                             String realName, int price, Boolean isLiked, Boolean isBookmarked, LocalDateTime createdTime) {
+                             String nickname, int price, Boolean isLiked, Boolean isBookmarked, LocalDateTime createdTime) {
         this.postId = postId;
         this.title = title;
         this.region = region;
@@ -42,7 +42,7 @@ public class FeedResultPostDto {
         this.viewCount = viewCount;
         this.userId = userId;
         this.profileImgURL = profileImgURL;
-        this.realName = realName;
+        this.nickname = nickname;
         this.price = price;
         this.isLiked = isLiked;
         this.isBookmarked = isBookmarked;

--- a/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
@@ -12,9 +12,13 @@ import java.time.LocalDateTime;
 @Setter
 public class SearchFeedConditionDto {
 
-    String searchKeyword;
+    private String searchKeyword;
 
-    SortStrategy sortStrategy;
+    private Long cursorId;
+
+    private Long size;
+
+    private SortStrategy sortStrategy;
 
     private SoldOption soldOption;
 
@@ -25,8 +29,11 @@ public class SearchFeedConditionDto {
     private Integer forLastMin;
 
     @Builder
-    public SearchFeedConditionDto(String searchKeyword, SortStrategy sortStrategy, SoldOption soldOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
+
+    public SearchFeedConditionDto(String searchKeyword, Long cursorId, Long size, SortStrategy sortStrategy, SoldOption soldOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
         this.searchKeyword = searchKeyword;
+        this.cursorId = cursorId;
+        this.size = size;
         this.sortStrategy = sortStrategy;
         this.soldOption = soldOption;
         this.dateFrom = dateFrom;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -1,12 +1,12 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+
+import java.util.List;
 
 public interface FeedRepositoryCustom {
 
-    Page<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Pageable pageable);
-
+    List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost);
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
@@ -131,7 +131,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
             case LIKE:
                 return ExpressionUtils.or(post.postLikeList.size().ne(cursorPost.getPostLikeList().size()), post.id.lt(cursorPost.getId()));
             case VIEW:
-                return post.viewCount.loe(cursorPost.getViewCount());
+                return ExpressionUtils.or(post.viewCount.ne(cursorPost.getViewCount()), post.id.lt(cursorPost.getId()));
             case CHRONOLOGICAL:
             default:
                 return null;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
@@ -1,20 +1,20 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.QFeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SortStrategy;
 import com.querydsl.core.Tuple;
+import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
 import javax.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -24,9 +24,9 @@ import static com.dope.breaking.domain.post.QPostLike.*;
 import static com.dope.breaking.domain.post.QPost.post;
 import static com.dope.breaking.domain.user.QUser.user;
 
+@Repository
 public class FeedRepositoryImpl implements FeedRepositoryCustom {
 
-    @Autowired EntityManager em;
     private final JPAQueryFactory queryFactory;
 
     public FeedRepositoryImpl(EntityManager em) {
@@ -34,21 +34,22 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public Page<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Pageable pageable) {
+    public List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost) {
 
         List<Tuple> paginatedResult = queryFactory
                 .select(post.id, postLike.post.id.count())
                 .from(post)
                 .leftJoin(post.postLikeList, postLike)
-                .where( // 세부필터 동적 쿼리 함수로 구현하여 추가
+                .where(
                         post.isHidden.eq(false),
                         soldOption(searchFeedConditionDto.getSoldOption()),
-                        period(searchFeedConditionDto.getDateFrom(),searchFeedConditionDto.getDateTo())
+                        period(searchFeedConditionDto.getDateFrom(), searchFeedConditionDto.getDateTo()),
+                        cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
+                        sameLevelCursorFilter(cursorPost, searchFeedConditionDto.getSortStrategy())
                 )
-                .groupBy(post.id)
-                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()))
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
+                .groupBy(post.id, postLike.post.id)
+                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()), boardSort(SortStrategy.CHRONOLOGICAL))
+                .limit(searchFeedConditionDto.getSize())
                 .fetch();
 
         List<Long> contentIdList = paginatedResult.stream().map(x -> x.get(post.id)).collect(Collectors.toList());
@@ -65,7 +66,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                         post.viewCount,
                         user.id,
                         user.compressedProfileImgURL,
-                        user.realName,
+                        user.nickname,
                         post.price,
                         Expressions.asBoolean(false),
                         Expressions.asBoolean(false),
@@ -75,10 +76,10 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .from(post)
                 .leftJoin(post.user, user)
                 .where(post.id.in(contentIdList))
-                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()))
+                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()), boardSort(SortStrategy.CHRONOLOGICAL))
                 .fetch();
 
-        return new PageImpl<>(content, pageable, content.size());
+        return content;
     }
 
 
@@ -102,6 +103,41 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         }
     }
 
+    private Predicate cursorPagination(Post cursorPost, SortStrategy sortStrategy) {
+
+        if(cursorPost == null) {
+            return null;
+        }
+
+        switch (sortStrategy) {
+            case LIKE:
+                return post.postLikeList.size().loe(cursorPost.getPostLikeList().size());
+            case VIEW:
+                return post.viewCount.loe(cursorPost.getViewCount());
+            case CHRONOLOGICAL:
+                return post.id.lt(cursorPost.getId());
+            default:
+                return null;
+        }
+    }
+
+    private Predicate sameLevelCursorFilter(Post cursorPost, SortStrategy sortStrategy) {
+
+        if(cursorPost == null) {
+            return null;
+        }
+
+        switch (sortStrategy) {
+            case LIKE:
+                return ExpressionUtils.or(post.postLikeList.size().ne(cursorPost.getPostLikeList().size()), post.id.lt(cursorPost.getId()));
+            case VIEW:
+                return post.viewCount.loe(cursorPost.getViewCount());
+            case CHRONOLOGICAL:
+            default:
+                return null;
+        }
+    }
+
     private OrderSpecifier<?> boardSort(SortStrategy sortStrategy) {
 
         if(sortStrategy == null){
@@ -110,7 +146,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 
         switch (sortStrategy){
             case LIKE:
-                return new OrderSpecifier<>(Order.DESC, postLike.post.id.count());
+                return new OrderSpecifier<>(Order.DESC, post.postLikeList.size());
             case VIEW:
                 return new OrderSpecifier<>(Order.DESC, post.viewCount);
             case CHRONOLOGICAL:

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -1,30 +1,37 @@
 package com.dope.breaking.service;
 
-import com.dope.breaking.domain.user.User;
+import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.repository.FeedRepository;
-import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class SearchFeedService {
 
     private final FeedRepository feedRepository;
+    private final PostRepository postRepository;
 
-    public Page<FeedResultPostDto> searchFeed(SearchFeedConditionDto searchFeedConditionDto, Pageable pageable) {
+    public List<FeedResultPostDto> searchFeed(SearchFeedConditionDto searchFeedConditionDto) {
+
+        Post cursorPost = null;
+        if(searchFeedConditionDto.getCursorId() != null && searchFeedConditionDto.getCursorId() != 0) {
+            cursorPost = postRepository.findById(searchFeedConditionDto.getCursorId()).orElseThrow(NoSuchPostException::new);
+        }
 
         if(searchFeedConditionDto.getForLastMin() != null) {
             searchFeedConditionDto.setDateFrom(LocalDateTime.now().minusMinutes(searchFeedConditionDto.getForLastMin()));
             searchFeedConditionDto.setDateTo(LocalDateTime.now());
         }
-        return feedRepository.searchFeedBy(searchFeedConditionDto, pageable);
+
+        return feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost);
     }
 
 }

--- a/src/test/java/com/dope/breaking/service/FeedSearchServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedSearchServiceTest.java
@@ -2,19 +2,19 @@ package com.dope.breaking.service;
 
 import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
 import com.dope.breaking.domain.post.PostType;
+import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.repository.FeedRepository;
+import com.dope.breaking.repository.PostLikeRepository;
 import com.dope.breaking.repository.PostRepository;
-import org.junit.jupiter.api.BeforeEach;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -26,16 +26,32 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 @SpringBootTest
 class FeedSearchServiceTest {
+
     @Autowired PostRepository postRepository;
     @Autowired FeedRepository feedRepository;
+    @Autowired PostLikeRepository postLikeRepository;
     @Autowired SearchFeedService searchFeedService;
     @Autowired EntityManager em;
+    @Autowired UserRepository userRepository;
 
-    @BeforeEach
-    void create100DummyPosts(TestInfo info) {
-        if (info.getDisplayName().equals("whenThereAreNoPosts()")) {
-            return; // skip @BeforeEach in whenThereAreNoPosts test
-        }
+    @DisplayName("포스트가 없으면, 에러가 나지 않고 빈 배열을 반환한다.")
+    @Test
+    void whenThereAreNoPosts() {
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .cursorId(null)
+                .size(15L)
+                .soldOption(SoldOption.SOLD)
+                .build();
+
+        List<FeedResultPostDto> result = searchFeedService.searchFeed(searchFeedConditionDto);
+
+        assertEquals(0, result.size());
+    }
+
+    @DisplayName("일반 포스트 90개와, 숨김 처리된 포스트 10개를 생성하고, 15개씩 조회한다.")
+    @Test
+    void get15postsWithoutFilterFrom100Dummy() {
 
         for(int i = 0; i<30; i++) {
             Post post = Post.builder()
@@ -53,7 +69,7 @@ class FeedSearchServiceTest {
 
         for(int i = 0; i<30; i++) {
             Post post = Post.builder()
-                    .title("title"+i)
+                    .title("title"+(i+30))
                     .content("content"+i)
                     .postType(PostType.EXCLUSIVE)
                     .location(Location.builder().region("exampleRegion").latitude(i*100.0).longitude(i*100.0).build())
@@ -67,7 +83,7 @@ class FeedSearchServiceTest {
 
         for(int i = 0; i<30; i++) {
             Post post = Post.builder()
-                    .title("title"+i)
+                    .title("title"+(i+60))
                     .content("content"+i)
                     .postType(PostType.FREE)
                     .location(Location.builder().region("exampleRegion").latitude(i*100.0).longitude(i*100.0).build())
@@ -92,45 +108,35 @@ class FeedSearchServiceTest {
                     .build();
             postRepository.save(post);
         }
-    }
 
-    @Test
-    void whenThereAreNoPosts() {
-        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
-                .builder()
-                .soldOption(SoldOption.SOLD)
-                .build();
-        Pageable pageable = PageRequest.of(0, 10);;
-
-        Page<FeedResultPostDto> paginationResult = searchFeedService.searchFeed(searchFeedConditionDto, pageable);
-        List<FeedResultPostDto> content = paginationResult.getContent();
-
-        assertEquals(0, content.size());
-    }
-
-    @Test
-    void get15postsWithoutFilter() {
+        Long page = 15L;
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
+                .cursorId(null)
+                .size(page)
                 .soldOption(SoldOption.ALL)
+                .sortStrategy(SortStrategy.CHRONOLOGICAL)
                 .build();
-        Pageable pageable1 = PageRequest.of(0, 15);
-        Pageable pageable2 = PageRequest.of(5, 15);
-        Pageable lastPageable = PageRequest.of(6, 15);
 
-        Page<FeedResultPostDto> paginationResult1 = searchFeedService.searchFeed(searchFeedConditionDto, pageable1);
-        List<FeedResultPostDto> content1 = paginationResult1.getContent();
+        List<FeedResultPostDto> content1 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content1.get(content1.size() - 1).getPostId());
+        List<FeedResultPostDto> content2 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content2.get(content2.size() - 1).getPostId());
+        List<FeedResultPostDto> content3 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content3.get(content3.size() - 1).getPostId());
+        List<FeedResultPostDto> content4 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content4.get(content4.size() - 1).getPostId());
+        List<FeedResultPostDto> content5 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content5.get(content5.size() - 1).getPostId());
+        List<FeedResultPostDto> content6 = searchFeedService.searchFeed(searchFeedConditionDto);
+        searchFeedConditionDto.setCursorId(content6.get(content6.size() - 1).getPostId());
+        List<FeedResultPostDto> content7 = searchFeedService.searchFeed(searchFeedConditionDto);
 
-        Page<FeedResultPostDto> paginationResult2 = searchFeedService.searchFeed(searchFeedConditionDto, pageable2);
-        List<FeedResultPostDto> content2 = paginationResult2.getContent();
-
-        Page<FeedResultPostDto> lastPaginationResult = searchFeedService.searchFeed(searchFeedConditionDto, lastPageable);
-        List<FeedResultPostDto> lastContent = lastPaginationResult.getContent();
-
-        assertEquals(15, content1.size());
-        assertEquals(15, content2.size());
-        assertEquals(0, lastContent.size(), () -> "6번 페이지는, 0개가 나와야 한다.");
+        assertEquals(page, content1.size());
+        assertEquals(page, content2.size());
+        assertEquals(page, content6.size());
+        assertEquals(0, content7.size(), () -> "남은 포스트 10개는 숨김처리되어 조회되지 않는다.");
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #134 

## 예상 리뷰 시간
???-min
querydsl의 동적쿼리에 대해서 궁금하시다면, 한 번 읽어보시면 좋을 것 같습니다.

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존 pagination 방식은, 전통적인 1,2,3,4 page 단위로 조회를 하는 방식이였습니다.
이 방식에서의 문제는, 인피니티 스크롤링을 적용할 경우
만약 중간에 게시글이 추가된다면 같은 내용의 게시글이 또 UI에 나타나는 것입니다.

그래서 이번에 적용한 cursor-based 방식은,
client가 마지막으로 받은 id를 cursor로 지정해서 요청하면, 그 이후의 결과를 계산하여 return 해주는 방식입니다.

날짜 순서 같은 경우에는, PK값을 활용하면 쉽지만,
like 순서, 좋아요 순서에서 많이 애먹었습니다.

한계점은, 좋아요 취소 같은 '취소 가능한' 행동의 경우에는 중복 현상이 또 나타날 수 있다는 것입니다.
이거는 아마 프론트에서 처리를 해야하는 문제로 보입니다.. (연결에 대한 상태유지를 하지 않으므로..)

숨 좀 돌리고 와서, 다음 작업 진행하겠습니다 ~~
- 유저 페이지 피드 (날아간 브랜치..)
- Redis 적용
- 댓글 조회
- 대댓글 조회

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/180838382-b8ad583b-497f-4e3e-8380-346265c92bfb.png)
![image](https://user-images.githubusercontent.com/76773202/180839498-e6d8e4ce-e7f6-4f5a-b5e3-0014477715e4.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
