### PR TITLE
feat: refactor PostAPI and PostService test code  and add TotalCommentCount and isPurchased field in Post-lookup

### DIFF
--- a/src/main/java/com/dope/breaking/domain/financial/Purchase.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Purchase.java
@@ -2,11 +2,14 @@ package com.dope.breaking.domain.financial;
 
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@NoArgsConstructor
 @Getter
 public class Purchase {
 
@@ -21,5 +24,12 @@ public class Purchase {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn (name = "POST_ID")
     private Post post;
+
+    @Builder
+    public Purchase(User user, Post post){
+        this.post = post;
+        this.user = user;
+
+    }
 
 }

--- a/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
@@ -23,6 +23,10 @@ public class DetailPostResponseDto {
 	@JsonProperty(value = "isBookmarked")
 	private boolean isBookmarked;
 
+
+	@JsonProperty(value = "isPurchased")
+	private boolean isPurchased;
+
 	private WriterDto user;
 
 	private String title;
@@ -63,10 +67,13 @@ public class DetailPostResponseDto {
 
 	private int likeCount;
 
+	private int totalCommentCount;
+
 	@Builder
-	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked, WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdTime, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount) {
+	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked,boolean isPurchased ,WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdTime, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount, int totalCommentCount) {
 		this.isLiked = isLiked;
 		this.isBookmarked = isBookmarked;
+		this.isPurchased = isPurchased;
 		this.user = user;
 		this.title = title;
 		this.content = content;
@@ -85,6 +92,7 @@ public class DetailPostResponseDto {
 		this.bookmarkedCount = bookmarkedCount;
 		this.isHidden = isHidden;
 		this.likeCount = likeCount;
+		this.totalCommentCount = totalCommentCount;
 	}
 }
 

--- a/src/main/java/com/dope/breaking/repository/CommentRepository.java
+++ b/src/main/java/com/dope/breaking/repository/CommentRepository.java
@@ -10,4 +10,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
     List<Comment> findAllByPost(Post post);
 
+    int countByPost(Post post);
+
 }

--- a/src/main/java/com/dope/breaking/repository/PurchaseRepository.java
+++ b/src/main/java/com/dope/breaking/repository/PurchaseRepository.java
@@ -2,10 +2,13 @@ package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.financial.Purchase;
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PurchaseRepository extends JpaRepository<Purchase, Long> {
     int countByPost(Post post);
 
     boolean existsByPost(Post post);
+
+    boolean existsByPostAndUser(Post post, User user);
 }

--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -3,6 +3,7 @@ package com.dope.breaking.api;
 import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.LocationDto;
@@ -17,6 +18,7 @@ import com.dope.breaking.service.UserService;
 import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.aspectj.lang.annotation.Before;
 import org.assertj.core.api.Assertions;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -41,7 +43,9 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityManager;
 import java.io.FileInputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
@@ -50,9 +54,11 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+
+
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
+@Transactional
 @AutoConfigureMockMvc // @WebMvcTest와 가장 큰 차이점은 컨트롤러 뿐만 아니라 테스트 대상이 아닌 @Service나 @Repository가 붙은 객체들도 모두 메모리에 올린다. 즉, 서비스단과 컨트롤러단의 테스트가 가능해짐.
 class PostAPITest {
 
@@ -80,14 +86,54 @@ class PostAPITest {
     PostLikeRepository postLikeRepository;
 
     @Autowired
+    EntityManager entityManager;
+
+    @Autowired
     UserService userService;
 
-    static Long postId;
 
-    @DisplayName("게시글을 저장하기위해, 유저를 등록한다.")
-    @Order(1)
+
+    @DisplayName("로그인 없이 게시글을 생성할 시, 예외가 반환된다.")
     @Test
-    public void createUserInfo() {
+    public void createPostWithoutLogin() throws Exception {
+        MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"free\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.multipart("/post")
+                        .file(multipartFile1)
+                        .part(new MockPart("data", json.getBytes(StandardCharsets.UTF_8)))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().is4xxClientError()).andReturn();
+
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
+    }
+
+
+    @DisplayName("로그인 후 게시글을 생성할 시 정상적으로 등록된다.")
+    @WithMockCustomUser
+    @Test
+    public void createPostWithLogin() throws Exception {
         User user = User.builder()
                 .username("12345g")
                 .password(passwordEncoder.encode(UUID.randomUUID().toString()))
@@ -95,20 +141,12 @@ class PostAPITest {
                 .build();
 
         userRepository.save(user);
-    }
 
-    @DisplayName("게시글을 저장한다.")
-    @Order(2)
-    @WithMockCustomUser
-    @Test
-    public void testpost() throws Exception {
+
+
+
+
         MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
-        Location location = Location.builder()
-                .longitude(1.2)
-                .region("andong")
-                .latitude(1.3).build();
-        List<String> hashTags = new LinkedList<>();
-        hashTags.add("tag1");
 
         String json = "{" +
                 "\"title\" : \"hello\"," +
@@ -138,20 +176,89 @@ class PostAPITest {
 
         MockHttpServletResponse response = resultActions.getResponse();
         String content = response.getContentAsString();
-        JSONParser jsonParser = new JSONParser();
-        JSONObject jsonObject = (JSONObject) jsonParser.parse(content);
-        System.out.println(jsonObject.toJSONString());
-        postId = Long.parseLong(jsonObject.get("postId").toString());
-        System.out.println(postId);
-
+        System.out.println(content);
     }
 
 
-    @DisplayName("게시글을 수정한다.")
-    @Order(3)
+
+    @DisplayName("존재하지 않는 게시글을 수정하려고 할 시, 예외가 반환된다.")
     @WithMockCustomUser
     @Test
-    public void testmodify() throws Exception {
+    public void modifyNoSuchPost () throws Exception {
+        LocationDto location = LocationDto.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+        List<String> hashTags = new LinkedList<>();
+        hashTags.add("tag2");
+
+
+        PostRequestDto postRequestDto = PostRequestDto.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType("free")
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .locationDto(location)
+                .hashtagList(hashTags).build();
+
+        System.out.println(postRequestDto.toString());
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        String content = objectMapper.writeValueAsString(postRequestDto);
+
+        MockMultipartHttpServletRequestBuilder builder =
+                MockMvcRequestBuilders.multipart("/post/" + -1);
+        builder.with(new RequestPostProcessor() {
+            @Override
+            public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
+                request.setMethod("PUT");
+                return request;
+            }
+        });
+
+
+        MvcResult resultActions = this.mockMvc.perform(builder
+                        .content(content)
+                        .characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String contentBody = response.getContentAsString();
+        System.out.println(contentBody);
+    }
+
+
+
+
+
+    @DisplayName("타인의 게시글을 수정하려 할 시, 예외가 반환된다.")
+    @WithMockCustomUser
+    @Test
+    public void modifyNoPermission() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+
+
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        User user2 = User.builder()
+                .username("123")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.USER).build();
+        userRepository.save(user2);
+        post.setUser(user2);
+
         LocationDto location = LocationDto.builder()
                 .longitude(1.2)
                 .region("andong")
@@ -192,42 +299,266 @@ class PostAPITest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()).andReturn();
+                .andExpect(MockMvcResultMatchers.status().isNotAcceptable()).andReturn();
 
         MockHttpServletResponse response = resultActions.getResponse();
         String contentBody = response.getContentAsString();
+        System.out.println(contentBody);
+
     }
 
-    @DisplayName("게시글을 조회힌다.")
+    @DisplayName("작성자가 게시글을 수정하려 할 시, 정상적으로 수정된다.")
     @WithMockCustomUser
-    @Order(4)
+    @Test
+    public void modifyPost() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+
+
+
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        post.setUser(user);
+        LocationDto location = LocationDto.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+        List<String> hashTags = new LinkedList<>();
+        hashTags.add("tag2");
+
+
+        PostRequestDto postRequestDto = PostRequestDto.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType("free")
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .locationDto(location)
+                .hashtagList(hashTags).build();
+
+        System.out.println(postRequestDto.toString());
+        ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+        String content = objectMapper.writeValueAsString(postRequestDto);
+
+        MockMultipartHttpServletRequestBuilder builder =
+                MockMvcRequestBuilders.multipart("/post/" + postId);
+        builder.with(new RequestPostProcessor() {
+            @Override
+            public MockHttpServletRequest postProcessRequest(MockHttpServletRequest request) {
+                request.setMethod("PUT");
+                return request;
+            }
+        });
+
+
+        MvcResult resultActions = this.mockMvc.perform(builder
+                        .content(content)
+                        .characterEncoding("UTF-8")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String contentBody = response.getContentAsString();
+        System.out.println(contentBody);
+
+    }
+
+
+    @DisplayName("존재하지 않는 게시글을 접근하려 할 시, 예외가 반환된다.")
+    @Test
+    public void readNoSuchPost() throws Exception {
+
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.get("/post/" + -1))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
+    }
+
+
+
+
+
+
+    @DisplayName("익명의 사용자가 게시글을 조회힌다.")
     @Test
     public void readPostWithAnonymous() throws Exception {
+
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+        Location location = Location.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+
+
+        Post post= Post.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType(PostType.FREE)
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .location(location)
+                .build();
+
+
+        long postId = postRepository.save(post).getId();
+        post.setUser(user);
+
+
         MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.get("/post/" + postId))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.isLiked").value(false))
-                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()).andReturn();
+                .andExpect(MockMvcResultMatchers.jsonPath("$.isBookmarked").value(false))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
 
         MockHttpServletResponse response = resultActions.getResponse();
         String content = response.getContentAsString();
         System.out.println(content);
     }
 
-    @DisplayName("게시글을 삭제한다.")
+
+    @DisplayName("로그인된 사용자가 게시글을 조회힌다.")
     @WithMockCustomUser
-    @Order(5)
     @Test
-    public void deletePost() throws Exception {
+    public void readPostWithAuthentication() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+        Location location = Location.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+
+
+        Post post= Post.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType(PostType.FREE)
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .location(location)
+                .build();
+
+        long postId = postRepository.save(post).getId();
+        post.setUser(user);
+
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.get("/post/" + postId))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.isLiked").value(false))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.isBookmarked").value(false))
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
+    }
+
+
+
+
+
+
+    @DisplayName("존재하지 않는 게시글을 삭제할 시, 예외가 반환된다.")
+    @WithMockCustomUser
+    @Test
+    public void deleteNoSuchPost() throws Exception {
+
+
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/" + -1))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNotFound()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
+    }
+
+    @DisplayName("타인의 게시글을 삭제할 시, 예외가 반환된다.")
+    @WithMockCustomUser
+    @Test
+    public void deleteNoPermission() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+
+
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        User user1 = User.builder()
+                .username("123")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.USER).build();
+        userRepository.save(user1);
+        post.setUser(user1);
+
         MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/" + postId))
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is2xxSuccessful()).andReturn();
+                .andExpect(MockMvcResultMatchers.status().isNotAcceptable()).andReturn();
 
         MockHttpServletResponse response = resultActions.getResponse();
         String content = response.getContentAsString();
         System.out.println(content);
-
-
-        User user = userRepository.findByUsername("12345g").get();
-        userRepository.delete(user);
     }
+
+
+    @DisplayName("작성자가 게시글을 삭제할 시, 삭제된다.")
+    @WithMockCustomUser
+    @Test
+    public void deletePost() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+
+
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        post.setUser(user);
+        MvcResult resultActions = this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/" + postId))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isNoContent()).andReturn();
+
+        MockHttpServletResponse response = resultActions.getResponse();
+        String content = response.getContentAsString();
+        System.out.println(content);
+    }
+
+
+
 }

--- a/src/test/java/com/dope/breaking/service/PostServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostServiceTest.java
@@ -1,0 +1,411 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.Purchase;
+import com.dope.breaking.domain.post.Location;
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.post.PostType;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.post.DetailPostResponseDto;
+import com.dope.breaking.dto.post.LocationDto;
+import com.dope.breaking.dto.post.PostRequestDto;
+import com.dope.breaking.exception.NotValidRequestBodyException;
+import com.dope.breaking.exception.post.NoSuchPostException;
+import com.dope.breaking.exception.post.PurchasedPostException;
+import com.dope.breaking.exception.user.NoPermissionException;
+import com.dope.breaking.repository.*;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.persistence.EntityManager;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+class PostServiceTest {
+
+    @Autowired
+    PostService postService;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    MediaService mediaService;
+
+    @Autowired
+    MediaRepository mediaRepository;
+
+    @Autowired
+    PostLikeRepository postLikeRepository;
+
+    @Autowired
+    PurchaseRepository purchaseRepository;
+
+    @Autowired
+    PostRepository postRepository;
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+
+    @Autowired
+    EntityManager entityManager;
+
+    @Autowired
+    UserService userService;
+
+
+    @BeforeEach
+    @Test
+    void saveUser() {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.PRESS) // 최초 가입시 USER 로 설정
+                .build();
+        userRepository.save(user);
+    }
+
+    @DisplayName(value = "요청 내용이 모두 충족될 시, 게시글은 저장된다.")
+    @Test
+    void create() throws Exception {
+        //Given
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"free\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        //When
+        long postId = postService.create("12345g", json , multipartFiles);
+
+        //Then
+        Assertions.assertTrue(postRepository.existsById(postId));
+        Assertions.assertEquals("12345g", postRepository.getById(postId).getUser().getUsername());
+    }
+
+
+    @DisplayName(value = "요청 내용이 일부 누락될 시, 예외가 반환된다.")
+    @Test
+    void createWithNullField() throws Exception {
+        //Given
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : null," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"free\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+
+        //Then
+        Assertions.assertThrows(NotValidRequestBodyException.class, () -> postService.create("12345g", json , multipartFiles)); //When
+    }
+
+
+
+    @DisplayName(value = "작성자가 게시글을 수정할 시, 정상적으로 수정이 된다.")
+    @Test
+    void modify() throws Exception {
+        //Given
+        LocationDto location = LocationDto.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+        List<String> hashTags = new LinkedList<>();
+        hashTags.add("tag2");
+
+
+        PostRequestDto postRequestDto = PostRequestDto.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType("free")
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .locationDto(location)
+                .hashtagList(hashTags).build();
+
+        Post post = new Post();
+        Long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        //When
+        postService.modify(postId, "12345g", postRequestDto);
+
+        //Then
+        Assertions.assertEquals("12345g", post.getUser().getUsername());
+        Assertions.assertEquals("title", post.getTitle());
+        Assertions.assertEquals("content", post.getContent());
+        Assertions.assertEquals(123, post.getPrice());
+    }
+
+    @DisplayName(value = "누락된 필드가 존재한다면, 예외가 반환된다.")
+    @Test
+    void modifyWithNullField() throws Exception {
+        //Given
+        LocationDto location = LocationDto.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+        List<String> hashTags = new LinkedList<>();
+        hashTags.add("tag2");
+
+
+        PostRequestDto postRequestDto = PostRequestDto.builder()
+                .title(null)
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType("free")
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .locationDto(location)
+                .hashtagList(hashTags).build();
+
+        Post post = new Post();
+        Long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        //Then
+        Assertions.assertThrows(NotValidRequestBodyException.class, () -> postService.modify(postId, "12345g", postRequestDto));
+
+    }
+
+
+
+    @DisplayName(value = "없는 게시글을 수정하려 할 시, 예외가 반환된다.")
+    @Test
+    void modifyNoSuchPost() throws Exception {
+        //Given
+        LocationDto location = LocationDto.builder().build();
+
+        PostRequestDto postRequestDto = PostRequestDto.builder().build();
+
+        Post post = new Post();
+        Long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        //Then
+        Assertions.assertThrows(NoSuchPostException.class, () -> postService.modify(-1, "12345g", postRequestDto));//When
+
+    }
+
+    @DisplayName(value = "타 유저의 게시글을 수정하려 할 시, 예외가 반환된다.")
+    @Test
+    void modifyNoPermission() throws Exception {
+        //Given
+        LocationDto location = LocationDto.builder().build();
+
+        PostRequestDto postRequestDto = PostRequestDto.builder().build();
+
+        Post post = new Post();
+        Long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        User user1  = User.builder()
+                .username("123g").build();
+        userRepository.save(user1);
+
+        //Then
+        Assertions.assertThrows(NoPermissionException.class, () -> postService.modify(postId, "123g", postRequestDto));//When
+    }
+
+
+
+
+
+    @DisplayName(value = "로그인을 하지 않은 유저가 게시글을 조회하려고 할 시, 게시글이 반환된다.")
+    @Test
+    void readWithAnonymous() {
+        Location location = Location.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+
+
+        Post post= Post.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType(PostType.FREE)
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .location(location)
+                .build();
+
+
+        long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        //When
+        DetailPostResponseDto detailPostResponseDto = postService.read(postId, null);
+
+        //Then
+        Assertions.assertFalse(detailPostResponseDto.isBookmarked());
+        Assertions.assertFalse(detailPostResponseDto.isLiked());
+        Assertions.assertFalse(detailPostResponseDto.isPurchased());
+    }
+
+
+    @DisplayName(value = "로그인한 사용자가 게시글 조회 시, 게시글이 반환한다.")
+    @Test
+    void readWithLikedUser() {
+        Location location = Location.builder()
+                .longitude(1.2)
+                .region("andong")
+                .latitude(1.3).build();
+
+
+        Post post= Post.builder()
+                .title("title")
+                .content("content")
+                .price(123)
+                .isAnonymous(false)
+                .postType(PostType.FREE)
+                .eventTime(LocalDateTime.parse("2016-10-31 23:59:59",
+                        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .location(location)
+                .build();
+
+
+        long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+        //When
+        DetailPostResponseDto detailPostResponseDto = postService.read(postId, "12345g");
+
+        //Then
+        Assertions.assertFalse(detailPostResponseDto.isBookmarked());
+        Assertions.assertFalse(detailPostResponseDto.isLiked());
+        Assertions.assertFalse(detailPostResponseDto.isPurchased());
+    }
+
+    @DisplayName("존재하지 않는 게시글을 삭제할 시, 예외가 반환된다.")
+    @Test
+    void deleteNoSuchPost() {
+
+        //Given
+
+        //then
+        Assertions.assertThrows(NoSuchPostException.class, () -> postService.delete(-1, "12345g")); //When
+
+    }
+
+    @DisplayName("타 유저가 작성한 게시글을 삭제할 시, 예외가 반환된다.")
+    @Test
+    void deleteNoPermission() {
+
+        //Given
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        User user = User.builder()
+                .username("123").build();
+        userRepository.save(user);
+        post.setUser(user);
+
+        //then
+        Assertions.assertThrows(NoPermissionException.class, () -> postService.delete(postId, "12345g")); //When
+
+    }
+
+    @DisplayName("이미 구매가 된 게시글을 삭제할 시, 예외가 반환된다.")
+    @Test
+    void deletePurchasedPost() {
+
+        //Given
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+
+        post.setUser(user);
+
+        User buyer = User.builder().username("123").build();
+
+        userRepository.save(buyer);
+        Purchase purchase = Purchase.builder()
+                .post(post)
+                .user(buyer).build();
+
+        purchaseRepository.save(purchase);
+
+
+        //then
+        Assertions.assertThrows(PurchasedPostException.class, () -> postService.delete(postId, "12345g")); //When
+
+    }
+
+
+    @DisplayName("작성자가 게시글을 삭제할 시, 게시글이 삭제된다.")
+    @Test
+    void delete() {
+
+        //Given
+        Post post = new Post();
+        long postId = postRepository.save(post).getId();
+        User user = userRepository.findByUsername("12345g").get();
+        post.setUser(user);
+
+
+        //When
+        postService.delete(postId, "12345g");
+        //then
+        Assertions.assertFalse(postRepository.existsById(postId));
+
+
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #137 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. PostAPI의 테스트코드를 flow 방식이 아닌, 단독으로 실행할 수 있도록 하여 독립성을 보장하였습니다. 
2. PostService 테스트코드가 누락되어 추가하였습니다. PostService에서 예상되는 예외 또는 응답을 테스트화하여 코드의 안정성을 높였습니다. 
3. 게시글 상세 조회 시,  totalCommentCount 필드와 isPurchased 필드를 추가하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="520" alt="스크린샷 2022-07-26 오후 5 19 26" src="https://user-images.githubusercontent.com/62254434/180962098-4b8aee1d-b979-4b17-907a-2155c2896029.png">
<img width="749" alt="스크린샷 2022-07-26 오후 5 30 21" src="https://user-images.githubusercontent.com/62254434/180962136-0d25afb7-3593-42ff-982f-382eba966970.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
북마크 기능을 구현하도록 하겠습니다.