### PR TITLE
chore: db enviroment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-/src/main/resources/application-jwt.yml

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
     implementation 'commons-fileupload:commons-fileupload:1.4'
 	implementation 'commons-io:commons-io:2.11.0'
+	runtimeOnly 'mysql:mysql-connector-java'
 
 	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.11'
 	implementation group: 'org.jcodec', name: 'jcodec', version: '0.2.5'

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,2 @@
+jwt:
+  secret : "localjwt"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,9 @@
 spring:
   datasource:
-    url: jdbc:h2:~/local
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    url: jdbc:mysql://localhost:3306/breaking
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:

--- a/src/test/resources/application-jwt.yml
+++ b/src/test/resources/application-jwt.yml
@@ -1,0 +1,2 @@
+jwt:
+  secret : "testjwt"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,31 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test;MODE=MySQL
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        #        show_sql: true
+        format_sql: true
+  profiles:
+    include: jwt
+
+  h2:
+    console:
+      enabled: true
+      path: /console
+
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 200MB
+
+logging.level:
+  org.hibernate.SQL: debug
+
+


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #148 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 테스트코드 h2 memory에서 변경하도록 변경
- 로컬환경은 로컬 mysql 서버에 연결하여 workbench와 함께 사용하도록 변경

Tip.
Postman 으로 API 테스트를 할 때, sql workbench로 데이터를 만들어놓고 조회, 삭제, 수정 등 작업을 해볼 수 있습니다.

테스트용 패스워드, jwt 토큰값을 넣어놨으니 참고해주세요.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->