### PR TITLE
feat : implement API for user page feed

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -5,14 +5,13 @@ import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SearchFeedService;
 import com.dope.breaking.service.SortStrategy;
+import com.dope.breaking.service.UserPageFeedOption;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,7 +34,8 @@ public class FeedAPI {
             @RequestParam(value="sold-option", required = false, defaultValue = "ALL") String soldOption,
             @RequestParam(value="date-from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateFrom,
             @RequestParam(value="date-to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateTo,
-            @RequestParam(value="for-last-min", required = false) Integer forLastMin) {
+            @RequestParam(value="for-last-min", required = false) Integer forLastMin
+    ) {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .searchKeyword(searchKeyword)
@@ -47,6 +47,27 @@ public class FeedAPI {
                 .dateFrom(dateFrom)
                 .dateTo(dateTo)
                 .forLastMin(forLastMin)
+                .build();
+
+        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto));
+
+    }
+
+    @GetMapping("/feed/user/{ownerId}/{userFeedPostOption}")
+    public ResponseEntity<List<FeedResultPostDto>> searchUserFeed(
+            @PathVariable("ownerId") Long ownerId,
+            @PathVariable("userFeedPostOption") String userFeedPostOption,
+            @RequestParam(value="cursor") Long cursor,
+            @RequestParam(value="size") Long size,
+            @RequestParam(value="sold-option", required = false, defaultValue = "ALL") String soldOption
+    ) {
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .cursorId(cursor)
+                .size(size)
+                .ownerId(ownerId)
+                .soldOption(SoldOption.findMatchedEnum(soldOption))
+                .userPageFeedOption(UserPageFeedOption.findMatchedEnum(userFeedPostOption))
                 .build();
 
         return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto));

--- a/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
@@ -2,6 +2,7 @@ package com.dope.breaking.dto.post;
 
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SortStrategy;
+import com.dope.breaking.service.UserPageFeedOption;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Setter;
@@ -11,6 +12,8 @@ import java.time.LocalDateTime;
 @Data
 @Setter
 public class SearchFeedConditionDto {
+
+    private Long ownerId;
 
     private String searchKeyword;
 
@@ -22,6 +25,8 @@ public class SearchFeedConditionDto {
 
     private SoldOption soldOption;
 
+    private UserPageFeedOption userPageFeedOption;
+
     private LocalDateTime dateFrom;
 
     private LocalDateTime dateTo;
@@ -29,13 +34,14 @@ public class SearchFeedConditionDto {
     private Integer forLastMin;
 
     @Builder
-
-    public SearchFeedConditionDto(String searchKeyword, Long cursorId, Long size, SortStrategy sortStrategy, SoldOption soldOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
+    public SearchFeedConditionDto(Long ownerId, String searchKeyword, Long cursorId, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
+        this.ownerId = ownerId;
         this.searchKeyword = searchKeyword;
         this.cursorId = cursorId;
         this.size = size;
         this.sortStrategy = sortStrategy;
         this.soldOption = soldOption;
+        this.userPageFeedOption = userPageFeedOption;
         this.dateFrom = dateFrom;
         this.dateTo = dateTo;
         this.forLastMin = forLastMin;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
@@ -100,6 +100,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     }
 
     private Predicate soldOption(SoldOption soldOption) {
+
         switch (soldOption) {
             case SOLD:
                 return post.isSold.eq(true);

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.dope.breaking.dto.post.QFeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SortStrategy;
+import com.dope.breaking.service.UserPageFeedOption;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.ExpressionUtils;
 import com.querydsl.core.types.Order;
@@ -42,6 +43,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .leftJoin(post.postLikeList, postLike)
                 .where(
                         post.isHidden.eq(false),
+                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), searchFeedConditionDto.getOwnerId()),
                         soldOption(searchFeedConditionDto.getSoldOption()),
                         period(searchFeedConditionDto.getDateFrom(), searchFeedConditionDto.getDateTo()),
                         cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
@@ -82,6 +84,20 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
         return content;
     }
 
+    private Predicate userPageFeedOption(UserPageFeedOption userPageFeedOption, Long ownerId) {
+
+        if(userPageFeedOption == null) {
+            return null;
+        }
+
+        switch (userPageFeedOption) {
+            case BUY:
+            case BOOKMARK:
+            case WRITE:
+            default:
+                return post.user.id.eq(ownerId);
+        }
+    }
 
     private Predicate soldOption(SoldOption soldOption) {
         switch (soldOption) {
@@ -89,6 +105,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 return post.isSold.eq(true);
             case UNSOLD:
                 return post.isSold.eq(false);
+            case ALL:
             default:
                 return null;
         }
@@ -105,7 +122,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 
     private Predicate cursorPagination(Post cursorPost, SortStrategy sortStrategy) {
 
-        if(cursorPost == null) {
+        if(cursorPost == null || sortStrategy == null) {
             return null;
         }
 
@@ -115,15 +132,14 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
             case VIEW:
                 return post.viewCount.loe(cursorPost.getViewCount());
             case CHRONOLOGICAL:
-                return post.id.lt(cursorPost.getId());
             default:
-                return null;
+                return post.id.lt(cursorPost.getId());
         }
     }
 
     private Predicate sameLevelCursorFilter(Post cursorPost, SortStrategy sortStrategy) {
 
-        if(cursorPost == null) {
+        if(cursorPost == null || sortStrategy == null) {
             return null;
         }
 

--- a/src/main/java/com/dope/breaking/service/UserPageFeedOption.java
+++ b/src/main/java/com/dope/breaking/service/UserPageFeedOption.java
@@ -1,0 +1,16 @@
+package com.dope.breaking.service;
+
+public enum UserPageFeedOption {
+
+    WRITE,
+    BUY,
+    BOOKMARK;
+
+    public static UserPageFeedOption findMatchedEnum(String str) {
+        for (UserPageFeedOption el : UserPageFeedOption.values()) {
+            if (el.name().equalsIgnoreCase(str))
+                return el;
+        }
+        return WRITE;
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #80 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 기존에 사용하던 메인 피드를 활용해서, 유저페이지를 구현했습니다.
- 유저페이지에서만 작동하는 옵션인 'UserPageFeedOption' 을 추가하고, 동적쿼리로 구현하였습니다.
- 북마크한 제보, 구매한 제보는 북마크와 구매 기능이 모두 구현되면 구현합니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/181458605-3421d9d1-c147-4cbe-850d-8691c994985e.png)
