### PR TITLE
feat: implement deposit/withdraw feature

### DIFF
--- a/src/main/java/com/dope/breaking/api/FinancialAPI.java
+++ b/src/main/java/com/dope/breaking/api/FinancialAPI.java
@@ -1,0 +1,40 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.domain.financial.TransactionType;
+import com.dope.breaking.dto.financial.AmountRequestDto;
+import com.dope.breaking.service.StatementService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class FinancialAPI {
+
+    private final StatementService statementService;
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/financial/deposit")
+    public ResponseEntity deposit(Principal principal,@RequestBody @Valid AmountRequestDto depositAmount) {
+
+        statementService.depositOrWithdraw(principal.getName(), depositAmount.getAmount(), TransactionType.DEPOSIT);
+        return ResponseEntity.ok().build();
+
+    }
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/financial/withdraw")
+    public ResponseEntity withdraw(Principal principal, @RequestBody @Valid AmountRequestDto withdrawAmount) {
+
+        statementService.depositOrWithdraw(principal.getName(), withdrawAmount.getAmount(), TransactionType.WITHDRAW);
+        return ResponseEntity.ok().build();
+
+    }
+
+}

--- a/src/main/java/com/dope/breaking/domain/financial/Purchase.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Purchase.java
@@ -25,10 +25,14 @@ public class Purchase {
     @JoinColumn (name = "POST_ID")
     private Post post;
 
+    private int amount;
+
     @Builder
-    public Purchase(User user, Post post){
+    public Purchase(User user, Post post, int amount){
+
         this.post = post;
         this.user = user;
+        this.amount = amount;
 
     }
 

--- a/src/main/java/com/dope/breaking/domain/financial/Statement.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Statement.java
@@ -1,12 +1,15 @@
 package com.dope.breaking.domain.financial;
 
 import com.dope.breaking.domain.user.User;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Statement {
 
     @Id @GeneratedValue
@@ -17,6 +20,18 @@ public class Statement {
     @JoinColumn (name = "USER_ID")
     private User user;
 
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+
     private int amount;
+
+    @Builder
+    public Statement(User user, TransactionType transactionType, int amount){
+
+        this.user = user;
+        this.transactionType = transactionType;
+        this.amount = amount;
+
+    }
 
 }

--- a/src/main/java/com/dope/breaking/domain/financial/Transaction.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Transaction.java
@@ -1,0 +1,50 @@
+package com.dope.breaking.domain.financial;
+
+
+import com.dope.breaking.domain.user.User;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="TRANSACTION_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name="USER_ID")
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "STATEMENT_ID")
+    private Statement statement;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn (name = "PURCHASE_ID")
+    private Purchase purchase;
+
+    private int amount;
+
+    @Enumerated(EnumType.STRING)
+    private TransactionType transactionType;
+
+    @Builder
+    public Transaction(User user, Statement statement, Purchase purchase, int amount, TransactionType transactionType){
+
+        this.user = user;
+        this.statement =  statement;
+        this.purchase = purchase;
+        this.amount = amount;
+        this.transactionType = transactionType;
+
+    }
+
+
+}

--- a/src/main/java/com/dope/breaking/domain/financial/TransactionType.java
+++ b/src/main/java/com/dope/breaking/domain/financial/TransactionType.java
@@ -1,0 +1,5 @@
+package com.dope.breaking.domain.financial;
+
+public enum TransactionType {
+    DEPOSIT, WITHDRAW, BUY_POST, SELL_POST;
+}

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -41,14 +41,9 @@ public class User {
     @OneToMany(mappedBy = "blocking")
     private List<Block> blockerList = new ArrayList<Block>();
 
-    //입출금 내역
-    @OneToMany(mappedBy = "user")
-    private List<Statement> statementList =  new ArrayList<Statement>();
-
     //거래 내역
     @OneToMany(mappedBy = "user")
     private List<Purchase> purchaseList = new ArrayList<Purchase>();
-
 
     @OneToMany(mappedBy = "user")
     private List<Bookmark> bookmarkList = new ArrayList<Bookmark>();
@@ -107,7 +102,6 @@ public class User {
         return this.role.getKey();
     }
 
-
     public void updateRefreshToken(String refreshToken){
         this.refreshToken = refreshToken;
     }
@@ -116,6 +110,6 @@ public class User {
         this.refreshToken = null;
     }
 
-
+    public void updateBalance(int amount) {this.balance += amount;}
 
 }

--- a/src/main/java/com/dope/breaking/dto/financial/AmountRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/financial/AmountRequestDto.java
@@ -1,0 +1,20 @@
+package com.dope.breaking.dto.financial;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AmountRequestDto {
+
+    @NotNull
+    @JsonProperty(value = "amount")
+    private int amount;
+
+}

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -35,7 +35,10 @@ public enum ErrorCode {
     ALREADY_UNLIKED("BSE459","이미 좋아요를 선택하지 않았습니다."),
 
 
-    INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패.")
+    INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패."),
+
+    NOT_ENOUGH_BALANCE("BSE601", "금액이 부족합니다.")
+
     ;
 
     private String code;

--- a/src/main/java/com/dope/breaking/exception/financial/NotEnoughBalanceException.java
+++ b/src/main/java/com/dope/breaking/exception/financial/NotEnoughBalanceException.java
@@ -1,0 +1,13 @@
+package com.dope.breaking.exception.financial;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NotEnoughBalanceException extends BreakingException {
+
+    public NotEnoughBalanceException() { super (ErrorCode.NOT_ENOUGH_BALANCE, HttpStatus.BAD_REQUEST);}
+
+}
+
+

--- a/src/main/java/com/dope/breaking/repository/StatementRepository.java
+++ b/src/main/java/com/dope/breaking/repository/StatementRepository.java
@@ -1,0 +1,7 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.financial.Statement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StatementRepository extends JpaRepository<Statement, Long> {
+}

--- a/src/main/java/com/dope/breaking/repository/TransactionRepository.java
+++ b/src/main/java/com/dope/breaking/repository/TransactionRepository.java
@@ -1,0 +1,7 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.financial.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TransactionRepository extends JpaRepository <Transaction, Long> {
+}

--- a/src/main/java/com/dope/breaking/service/StatementService.java
+++ b/src/main/java/com/dope/breaking/service/StatementService.java
@@ -1,0 +1,48 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.Statement;
+import com.dope.breaking.domain.financial.TransactionType;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.financial.NotEnoughBalanceException;
+import com.dope.breaking.repository.StatementRepository;
+import com.dope.breaking.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class StatementService {
+
+    private final StatementRepository statementRepository;
+    private final UserRepository userRepository;
+    private final TransactionService transactionService;
+
+    public void depositOrWithdraw (String username, int amount, TransactionType transactionType) {
+
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+
+        if (transactionType == TransactionType.DEPOSIT) {
+            user.updateBalance(amount);
+        }
+
+        else if (transactionType == TransactionType.WITHDRAW) {
+
+            if (user.getBalance() < amount) {
+                throw new NotEnoughBalanceException();
+            }
+
+            user.updateBalance(amount*(-1));
+
+        }
+
+        Statement statement = new Statement(user, transactionType, amount);
+        statementRepository.save(statement);
+
+        transactionService.depositOrWithdrawTransaction(user, statement);
+
+    }
+
+}

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -1,0 +1,24 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.Statement;
+import com.dope.breaking.domain.financial.Transaction;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+
+    public void depositOrWithdrawTransaction (User user, Statement statement){
+
+        Transaction transaction = new Transaction(user, statement,null, statement.getAmount(), statement.getTransactionType());
+        transactionRepository.save(transaction);
+
+    }
+}

--- a/src/test/java/com/dope/breaking/api/FinancialAPITest.java
+++ b/src/test/java/com/dope/breaking/api/FinancialAPITest.java
@@ -1,0 +1,179 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.domain.financial.TransactionType;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.financial.AmountRequestDto;
+import com.dope.breaking.repository.StatementRepository;
+import com.dope.breaking.repository.TransactionRepository;
+import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.service.StatementService;
+import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class FinancialAPITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private StatementRepository statementRepository;
+
+    @Autowired
+    private StatementService statementService;
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @BeforeEach
+    public void createUserInfo() {
+
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.USER) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+    }
+
+    @DisplayName("유저네임이 일치할시, 입금이 정상적으로 진행된다.")
+    @Test
+    @WithMockCustomUser
+    @Transactional
+    void deposit() throws Exception {
+
+        //Given
+        AmountRequestDto depositAmount = new AmountRequestDto(20000);
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(depositAmount);
+
+        //When
+        this.mockMvc.perform(post("/financial/deposit")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk()); //Then
+
+        //Then
+        Assertions.assertEquals(1, statementRepository.findAll().size());
+        Assertions.assertEquals(1, transactionRepository.findAll().size());
+        Assertions.assertEquals(20000, userRepository.findByUsername("12345g").get().getBalance());
+
+    }
+
+    @DisplayName("잔액이 출금액보다 많을 시, 출금이 정상적으로 진행된다.")
+    @Test
+    @WithMockCustomUser
+    @Transactional
+    void withdraw() throws Exception{
+
+        //Given
+        statementService.depositOrWithdraw("12345g",30000, TransactionType.DEPOSIT);
+
+        AmountRequestDto withdrawAmount = new AmountRequestDto(10000);
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(withdrawAmount);
+
+        //When
+        this.mockMvc.perform(post("/financial/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk()); //Then
+
+        //Then
+        Assertions.assertEquals(2, statementRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(20000, userRepository.findByUsername("12345g").get().getBalance());
+
+    }
+
+    @DisplayName("잔액이 출금액과 동일할 시, 출금이 정상적으로 진행된다.")
+    @Test
+    @WithMockCustomUser
+    @Transactional
+    void withdrawAll() throws Exception{
+
+        //Given
+        statementService.depositOrWithdraw("12345g",30000, TransactionType.DEPOSIT);
+
+        AmountRequestDto withdrawAmount = new AmountRequestDto(30000);
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(withdrawAmount);
+
+        //When
+        this.mockMvc.perform(post("/financial/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk()); //Then
+
+        //Then
+        Assertions.assertEquals(2, statementRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(0, userRepository.findByUsername("12345g").get().getBalance());
+
+    }
+
+    @DisplayName("잔액이 출금액보다 적을시, 예외가 발생한다.")
+    @Test
+    @WithMockCustomUser
+    @Transactional
+    void withdrawMoreThanBalance() throws Exception{
+
+        //Given
+        statementService.depositOrWithdraw("12345g",30000, TransactionType.DEPOSIT);
+
+        AmountRequestDto withdrawAmount = new AmountRequestDto(40000);
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(withdrawAmount);
+
+        //When
+        this.mockMvc.perform(post("/financial/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest()); //Then
+
+    }
+    
+}

--- a/src/test/java/com/dope/breaking/service/StatementServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/StatementServiceTest.java
@@ -1,0 +1,119 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.TransactionType;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.exception.financial.NotEnoughBalanceException;
+import com.dope.breaking.repository.StatementRepository;
+import com.dope.breaking.repository.TransactionRepository;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+class StatementServiceTest {
+
+    @Autowired
+    private StatementService statementService;
+
+    @Autowired
+    private StatementRepository statementRepository;
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @DisplayName("유저네임이 일치할 때 입금을 시도할 경우, 입금이 정상적으로 진행된다.")
+    @Test
+    void deposit() {
+
+        //Given
+        User user = new User();
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+
+        userRepository.save(user);
+
+        //When
+        statementService.depositOrWithdraw("username", 10000, TransactionType.DEPOSIT);
+        statementService.depositOrWithdraw("username", 20000, TransactionType.DEPOSIT);
+
+        //Then
+        Assertions.assertEquals(2, statementRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(30000, user.getBalance());
+
+    }
+
+    @DisplayName("잔액이 출금액보다 많을 경우, 출금이 정상적으로 진행된다.")
+    @Test
+    void withdraw() {
+
+        //Given
+        User user = new User();
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+
+        userRepository.save(user);
+
+        //When
+        statementService.depositOrWithdraw("username", 30000, TransactionType.DEPOSIT);
+        statementService.depositOrWithdraw("username", 20000, TransactionType.WITHDRAW);
+
+        //Then
+        Assertions.assertEquals(2, statementRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(10000, user.getBalance());
+
+    }
+
+    @DisplayName("잔액이 출금액이 동일할 경우, 출금이 정상적으로 진행된다.")
+    @Test
+    void withdrawAll() {
+
+        //Given
+        User user = new User();
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+
+        userRepository.save(user);
+
+        //When
+        statementService.depositOrWithdraw("username", 30000, TransactionType.DEPOSIT);
+        statementService.depositOrWithdraw("username", 30000, TransactionType.WITHDRAW);
+
+        //Then
+        Assertions.assertEquals(2, statementRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(00000, user.getBalance());
+
+    }
+
+    @DisplayName("잔액보다 많이 출금할 경우, 예외가 발생한다.")
+    @Test
+    void withdrawMoreThanBalance() {
+
+        //Given
+        User user = new User();
+        user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+
+        userRepository.save(user);
+
+        //When
+        statementService.depositOrWithdraw("username", 30000, TransactionType.DEPOSIT);
+
+        //Then
+        Assertions.assertThrows ( NotEnoughBalanceException.class, ()
+                -> statementService.depositOrWithdraw("username", 40000, TransactionType.WITHDRAW)); //When
+
+    }
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #150 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 엔티티 설계를 바꾸었습니다. **(스크린샷 참고!!)**
  1. Statement entity에 statementType 필드를 추가했습니다.
  2. Purchase entity에 구체금액 amount 필드를 추가했습니다. (제보자의 가격 변경 고려)
  3. Transaction entity 를 추가하여 유저의 모든 금전관련 내역을 기록하게 구현했습니다 (입/출금, 제보 판매/구매)
  4. TransactionType enum을 구현했습니다. (입/출금, 제보 판매/구매)
- 입/출금 기능을 구현했습니다.
  1. 입금 기능을 구현했습니다.
  2. 출금 기능을 구현했습니다.
    - 잔액보다 많이 출금할 경우 출금이 불가하게 구현했습니다.
- 해당하는 테스트 코드를 구현했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

<img width="376" alt="스크린샷 2022-07-28 오후 9 10 11" src="https://user-images.githubusercontent.com/87322089/181501797-8a1f995f-30f6-4213-9950-1658bf221922.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 제보 구매 기능을 구현하겠습니다.
