### PR TITLE
feat: add purchase post feature

### DIFF
--- a/src/main/java/com/dope/breaking/api/FinancialAPI.java
+++ b/src/main/java/com/dope/breaking/api/FinancialAPI.java
@@ -24,7 +24,7 @@ public class FinancialAPI {
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/financial/deposit")
-    public ResponseEntity deposit (Principal principal,@RequestBody @Valid AmountRequestDto depositAmount) {
+    public ResponseEntity deposit(Principal principal,@RequestBody @Valid AmountRequestDto depositAmount) {
 
         statementService.depositOrWithdraw(principal.getName(), depositAmount.getAmount(), TransactionType.DEPOSIT);
         return ResponseEntity.ok().build();
@@ -33,7 +33,7 @@ public class FinancialAPI {
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/financial/withdraw")
-    public ResponseEntity withdraw (Principal principal, @RequestBody @Valid AmountRequestDto withdrawAmount) {
+    public ResponseEntity withdraw(Principal principal, @RequestBody @Valid AmountRequestDto withdrawAmount) {
 
         statementService.depositOrWithdraw(principal.getName(), withdrawAmount.getAmount(), TransactionType.WITHDRAW);
         return ResponseEntity.ok().build();
@@ -42,7 +42,7 @@ public class FinancialAPI {
 
     @PreAuthorize("isAuthenticated")
     @PostMapping("/post/{postId}/purchase")
-    public ResponseEntity purchase (Principal principal, @PathVariable Long postId) {
+    public ResponseEntity purchase(Principal principal, @PathVariable Long postId) {
 
         purchaseService.purchasePost(principal.getName(), postId);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/dope/breaking/api/FinancialAPI.java
+++ b/src/main/java/com/dope/breaking/api/FinancialAPI.java
@@ -2,10 +2,12 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.domain.financial.TransactionType;
 import com.dope.breaking.dto.financial.AmountRequestDto;
+import com.dope.breaking.service.PurchaseService;
 import com.dope.breaking.service.StatementService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,10 +20,11 @@ import java.security.Principal;
 public class FinancialAPI {
 
     private final StatementService statementService;
+    private final PurchaseService purchaseService;
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/financial/deposit")
-    public ResponseEntity deposit(Principal principal,@RequestBody @Valid AmountRequestDto depositAmount) {
+    public ResponseEntity deposit (Principal principal,@RequestBody @Valid AmountRequestDto depositAmount) {
 
         statementService.depositOrWithdraw(principal.getName(), depositAmount.getAmount(), TransactionType.DEPOSIT);
         return ResponseEntity.ok().build();
@@ -30,9 +33,18 @@ public class FinancialAPI {
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/financial/withdraw")
-    public ResponseEntity withdraw(Principal principal, @RequestBody @Valid AmountRequestDto withdrawAmount) {
+    public ResponseEntity withdraw (Principal principal, @RequestBody @Valid AmountRequestDto withdrawAmount) {
 
         statementService.depositOrWithdraw(principal.getName(), withdrawAmount.getAmount(), TransactionType.WITHDRAW);
+        return ResponseEntity.ok().build();
+
+    }
+
+    @PreAuthorize("isAuthenticated")
+    @PostMapping("/post/{postId}/purchase")
+    public ResponseEntity purchase (Principal principal, @PathVariable Long postId) {
+
+        purchaseService.purchasePost(principal.getName(), postId);
         return ResponseEntity.ok().build();
 
     }

--- a/src/main/java/com/dope/breaking/domain/financial/Purchase.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Purchase.java
@@ -25,14 +25,14 @@ public class Purchase {
     @JoinColumn (name = "POST_ID")
     private Post post;
 
-    private int amount;
+    private int price;
 
     @Builder
-    public Purchase(User user, Post post, int amount){
+    public Purchase(User user, Post post, int price){
 
         this.post = post;
         this.user = user;
-        this.amount = amount;
+        this.price = price;
 
     }
 

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -75,6 +75,8 @@ public class Post extends BaseTimeEntity {
 
     private boolean isHidden;
 
+    private boolean isPurchasable = true;
+
     private LocalDateTime eventTime;
 
     private String thumbnailImgURL;
@@ -117,4 +119,9 @@ public class Post extends BaseTimeEntity {
     public void updateViewCount() {
         this.viewCount += 1;
     }
+
+    public void updateIsSold (boolean isSold) { this.isSold = isSold; }
+
+    public void updateIsPurchasable (boolean isPurchasable ) { this.isPurchasable = isPurchasable; }
+    
 }

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -123,5 +123,5 @@ public class Post extends BaseTimeEntity {
     public void updateIsSold (boolean isSold) { this.isSold = isSold; }
 
     public void updateIsPurchasable (boolean isPurchasable ) { this.isPurchasable = isPurchasable; }
-    
+
 }

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -29,7 +29,6 @@ public enum ErrorCode {
     ALREADY_UNFOLLOWING("BSE421","이미 언팔로우 중인 유저입니다."),
     NO_SUCH_POST("BSE450","해당 제보를 찾을 수 없습니다"),
     NO_SUCH_COMMENT("BSE451","해당 댓글을 찾을 수 없습니다"),
-
     PURCHASED_POST("BSE452", "판매된 게시글은 삭제할 수 없습니다."),
 
     ALREADY_BOOKMARKED("BSE456", "이미 북마크를 선택했습니다."),
@@ -37,7 +36,8 @@ public enum ErrorCode {
     ALREADY_UNBOOKMARKED("BSE457", "이미 북마크를 선택하지 않았습니다."),
     ALREADY_LIKED("BSE458","이미 좋아요를 선택했습니다."),
     ALREADY_UNLIKED("BSE459","이미 좋아요를 선택하지 않았습니다."),
-
+    NOT_PURCHASABLE_POST("BSE460","구매 제한이 된 포스트입니다."),
+    SOLD_EXCLUSIVE_POST("BSE461","이미 판매 된 단독제보입니다."),
 
     INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패."),
 

--- a/src/main/java/com/dope/breaking/exception/post/NotPurchasablePostException.java
+++ b/src/main/java/com/dope/breaking/exception/post/NotPurchasablePostException.java
@@ -4,8 +4,11 @@ import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
-public class PurchasedPostException extends BreakingException {
+public class NotPurchasablePostException extends BreakingException {
 
-    public PurchasedPostException() { super(ErrorCode.PURCHASED_POST, HttpStatus.NOT_ACCEPTABLE); }
+    public NotPurchasablePostException() { super(ErrorCode.NOT_PURCHASABLE_POST, HttpStatus.BAD_REQUEST); }
 
 }
+
+
+

--- a/src/main/java/com/dope/breaking/exception/post/SoldExclusivePostException.java
+++ b/src/main/java/com/dope/breaking/exception/post/SoldExclusivePostException.java
@@ -4,8 +4,10 @@ import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
-public class PurchasedPostException extends BreakingException {
+public class SoldExclusivePostException extends BreakingException {
 
-    public PurchasedPostException() { super(ErrorCode.PURCHASED_POST, HttpStatus.NOT_ACCEPTABLE); }
+    public SoldExclusivePostException() { super(ErrorCode.SOLD_EXCLUSIVE_POST, HttpStatus.BAD_REQUEST); }
 
 }
+
+

--- a/src/main/java/com/dope/breaking/service/PurchaseService.java
+++ b/src/main/java/com/dope/breaking/service/PurchaseService.java
@@ -1,0 +1,92 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.Purchase;
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostType;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.financial.NotEnoughBalanceException;
+import com.dope.breaking.exception.post.NoSuchPostException;
+import com.dope.breaking.exception.post.NotPurchasablePostException;
+import com.dope.breaking.exception.post.SoldExclusivePostException;
+import com.dope.breaking.repository.PostRepository;
+import com.dope.breaking.repository.PurchaseRepository;
+import com.dope.breaking.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PurchaseService {
+
+    private final PurchaseRepository purchaseRepository;
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final TransactionService transactionService;
+
+    public void purchasePost (String username, Long postId) {
+
+        User buyer = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        Post post = postRepository.findById(postId).orElseThrow(NoSuchPostException::new);
+
+        User seller = post.getUser();
+
+        if (!post.isPurchasable()) {
+            throw new NotPurchasablePostException();
+        }
+
+        if (post.getPostType() == PostType.FREE) {
+
+            Purchase purchase = new Purchase(buyer, post, post.getPrice());
+            purchaseRepository.save(purchase);
+            post.updateIsSold(true);
+
+        }
+
+        else if (post.getPostType() ==PostType.CHARGED) {
+
+            if (buyer.getBalance() < post.getPrice()) {
+                throw new NotEnoughBalanceException();
+            }
+
+            moneyTransfer (buyer, seller, post.getPrice());
+            Purchase purchase = new Purchase(buyer, post, post.getPrice());
+            purchaseRepository.save(purchase);
+
+            post.updateIsSold(true);
+
+            transactionService.purchasePostTransaction(buyer, seller, purchase);
+
+        }
+        else if (post.getPostType() == PostType.EXCLUSIVE) {
+
+            if (post.isSold()) {
+                throw new SoldExclusivePostException();
+            }
+
+            if (buyer.getBalance() < post.getPrice()) {
+                throw new NotEnoughBalanceException();
+            }
+
+            moneyTransfer (buyer, seller, post.getPrice());
+            Purchase purchase = new Purchase(buyer, post, post.getPrice());
+            purchaseRepository.save(purchase);
+
+            post.updateIsSold(true);
+
+            transactionService.purchasePostTransaction(buyer, seller, purchase);
+
+        }
+
+    }
+
+    public void moneyTransfer (User buyer, User seller, int amount) {
+
+        buyer.updateBalance(amount*(-1));
+        seller.updateBalance(amount);
+
+    }
+
+}

--- a/src/main/java/com/dope/breaking/service/PurchaseService.java
+++ b/src/main/java/com/dope/breaking/service/PurchaseService.java
@@ -26,7 +26,7 @@ public class PurchaseService {
     private final PostRepository postRepository;
     private final TransactionService transactionService;
 
-    public void purchasePost (String username, Long postId) {
+    public void purchasePost(String username, Long postId) {
 
         User buyer = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
         Post post = postRepository.findById(postId).orElseThrow(NoSuchPostException::new);
@@ -82,7 +82,7 @@ public class PurchaseService {
 
     }
 
-    public void moneyTransfer (User buyer, User seller, int amount) {
+    public void moneyTransfer(User buyer, User seller, int amount) {
 
         buyer.updateBalance(amount*(-1));
         seller.updateBalance(amount);

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -17,14 +17,14 @@ public class TransactionService {
 
     private final TransactionRepository transactionRepository;
 
-    public void depositOrWithdrawTransaction (User user, Statement statement){
+    public void depositOrWithdrawTransaction(User user, Statement statement){
 
         Transaction transaction = new Transaction(user, statement,null, statement.getAmount(), statement.getTransactionType());
         transactionRepository.save(transaction);
 
     }
 
-    public void purchasePostTransaction (User buyer, User seller, Purchase purchase){
+    public void purchasePostTransaction(User buyer, User seller, Purchase purchase){
 
         Transaction buyerTransaction = new Transaction(buyer, null, purchase, purchase.getPrice(), TransactionType.BUY_POST);
         Transaction sellerTransaction = new Transaction(seller, null, purchase, purchase.getPrice(), TransactionType.SELL_POST);

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -1,7 +1,9 @@
 package com.dope.breaking.service;
 
+import com.dope.breaking.domain.financial.Purchase;
 import com.dope.breaking.domain.financial.Statement;
 import com.dope.breaking.domain.financial.Transaction;
+import com.dope.breaking.domain.financial.TransactionType;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,4 +23,15 @@ public class TransactionService {
         transactionRepository.save(transaction);
 
     }
+
+    public void purchasePostTransaction (User buyer, User seller, Purchase purchase){
+
+        Transaction buyerTransaction = new Transaction(buyer, null, purchase, purchase.getPrice(), TransactionType.BUY_POST);
+        Transaction sellerTransaction = new Transaction(seller, null, purchase, purchase.getPrice(), TransactionType.SELL_POST);
+        transactionRepository.save(buyerTransaction);
+        transactionRepository.save(sellerTransaction);
+
+    }
+
+
 }

--- a/src/test/java/com/dope/breaking/service/MediaServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/MediaServiceTest.java
@@ -16,7 +16,6 @@ import java.util.List;
 
 @SpringBootTest
 @Transactional
-@Rollback(false)
 class MediaServiceTest {
 
     @Autowired MediaService mediaService;

--- a/src/test/java/com/dope/breaking/service/PostServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostServiceTest.java
@@ -3,7 +3,6 @@ package com.dope.breaking.service;
 import com.dope.breaking.domain.financial.Purchase;
 import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Post;
-import com.dope.breaking.domain.post.PostLike;
 import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
@@ -15,12 +14,10 @@ import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.exception.post.PurchasedPostException;
 import com.dope.breaking.exception.user.NoPermissionException;
 import com.dope.breaking.repository.*;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,15 +25,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.persistence.EntityManager;
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -52,28 +45,13 @@ class PostServiceTest {
     UserRepository userRepository;
 
     @Autowired
-    MediaService mediaService;
-
-    @Autowired
-    MediaRepository mediaRepository;
-
-    @Autowired
-    PostLikeRepository postLikeRepository;
-
-    @Autowired
     PurchaseRepository purchaseRepository;
 
     @Autowired
     PostRepository postRepository;
+
     @Autowired
     PasswordEncoder passwordEncoder;
-
-
-    @Autowired
-    EntityManager entityManager;
-
-    @Autowired
-    UserService userService;
 
 
     @BeforeEach

--- a/src/test/java/com/dope/breaking/service/PurchaseServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PurchaseServiceTest.java
@@ -1,0 +1,402 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.financial.NotEnoughBalanceException;
+import com.dope.breaking.exception.post.NoSuchPostException;
+import com.dope.breaking.exception.post.NotPurchasablePostException;
+import com.dope.breaking.exception.post.SoldExclusivePostException;
+import com.dope.breaking.repository.PostRepository;
+import com.dope.breaking.repository.PurchaseRepository;
+import com.dope.breaking.repository.TransactionRepository;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+class PurchaseServiceTest {
+
+    @Autowired
+    private PurchaseService purchaseService;
+
+    @Autowired
+    private PurchaseRepository purchaseRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostService postService;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private TransactionRepository transactionRepository;
+
+    @DisplayName("무료제보를 구매할 경우, 1. 제보가 정상적으로 구매 된다. 2. Transaction 이 생성되지 않는다. 3. balance 가 변하지 않는다.")
+    @Test
+    void purchaseFreePost() throws Exception {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(1000);
+        userRepository.save(buyer);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(2000);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 0," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"free\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        //When
+        purchaseService.purchasePost("buyer", postId);
+
+        //Then
+        Assertions.assertEquals(1, purchaseRepository.findAll().size());
+        Assertions.assertEquals(0, transactionRepository.findAll().size());
+        Assertions.assertEquals(1000, buyer.getBalance());
+        Assertions.assertEquals(2000, seller.getBalance());
+        Assertions.assertTrue(postRepository.getById(postId).isSold());
+
+    }
+
+    @DisplayName("구매자의 잔액이 제보 판매금액보다 클 경우, 1. 구매가 정상적으로 진행된다, 2. 구매자와 판매자의 잔액이 업데이트 된다. 3. Transaction 객체가 두 개 생성된다.")
+    @Test
+    void purchaseChargedPost() throws Exception {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(3000);
+        userRepository.save(buyer);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(4000);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"charged\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        //When
+        purchaseService.purchasePost("buyer", postId);
+
+        //Then
+        Assertions.assertEquals(1, purchaseRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(2000, buyer.getBalance());
+        Assertions.assertEquals(5000, seller.getBalance());
+
+    }
+
+
+    @DisplayName("구매자의 잔액이 제보 판매금액보다 작을 경우, 에러가 발생한다")
+    @Test
+    void purchasePostWhenPriceLargerThanBalance() throws Exception {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(999);
+        userRepository.save(buyer);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(0);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"charged\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+
+        //Then
+        Assertions.assertThrows(NotEnoughBalanceException.class, ()
+                -> purchaseService.purchasePost("buyer", postId)); //When
+
+        //Then
+        Assertions.assertEquals(0, purchaseRepository.findAll().size());
+        Assertions.assertEquals(0, transactionRepository.findAll().size());
+        Assertions.assertEquals(999, buyer.getBalance());
+        Assertions.assertEquals(0, seller.getBalance());
+
+
+    }
+
+    @DisplayName("판매되지 않은 단독제보를 구매할 경우, 정상적으로 구매된다.")
+    @Test
+    void purchaseExclusivePost() throws Exception {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(2000);
+        userRepository.save(buyer);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(0);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"exclusive\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        //When
+        purchaseService.purchasePost("buyer", postId);
+
+        //Then
+        Assertions.assertEquals(1, purchaseRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(1000, buyer.getBalance());
+        Assertions.assertEquals(1000, seller.getBalance());
+        Assertions.assertTrue(postRepository.getById(postId).isSold());
+
+    }
+
+    @DisplayName("판매된 단독제보를 구매할 경우, 예외가 발생한다.")
+    @Test
+    void purchaseSoldExclusivePost() throws Exception {
+
+        //Given
+        User buyer1 = new User();
+        buyer1.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer1", Role.USER);
+        buyer1.updateBalance(2000);
+        userRepository.save(buyer1);
+
+        User buyer2 = new User();
+        buyer2.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer2", Role.USER);
+        buyer2.updateBalance(2000);
+        userRepository.save(buyer2);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(0);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"exclusive\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        purchaseService.purchasePost("buyer1",postId);
+
+        //Then
+        Assertions.assertThrows(SoldExclusivePostException.class, ()
+                -> purchaseService.purchasePost("buyer2", postId)); //When
+
+        //Then
+        Assertions.assertEquals(1, purchaseRepository.findAll().size());
+        Assertions.assertEquals(2, transactionRepository.findAll().size());
+        Assertions.assertEquals(1000, buyer1.getBalance());
+        Assertions.assertEquals(2000, buyer2.getBalance());
+        Assertions.assertEquals(1000, seller.getBalance());
+
+
+    }
+
+    @DisplayName("구매 비활성화 된 제보를 구매할 경우, 예외가 발생한다.")
+    @Test
+    void purchaseNotPurchasablePost() throws Exception {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(2000);
+        userRepository.save(buyer);
+
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(0);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"exclusive\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        Post post = postRepository.getById(postId);
+        post.updateIsPurchasable(false);
+
+        //Then
+        Assertions.assertThrows(NotPurchasablePostException.class, ()
+                -> purchaseService.purchasePost("buyer", postId)); //When
+
+    }
+
+    @DisplayName("존재하지 않는 유저일 경우, 예외가 발생한다.")
+    @Test
+    void purchaseWithNotExistingUsername() throws Exception {
+
+        //Given
+        User seller = new User();
+        seller.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "seller", Role.USER);
+        seller.updateBalance(0);
+        userRepository.save(seller);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 1000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"exclusive\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId = postService.create("seller", json, multipartFiles);
+
+        //Then
+        Assertions.assertThrows(InvalidAccessTokenException.class, ()
+                -> purchaseService.purchasePost("weirdUsername", postId)); //When
+
+    }
+
+    @DisplayName("존재하지 않는 제보를 구매할 경우, 예외가 발생한다.")
+    @Test
+    void purchaseNotExistingPost () {
+
+        //Given
+        User buyer = new User();
+        buyer.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "buyer", Role.USER);
+        buyer.updateBalance(2000);
+        userRepository.save(buyer);
+
+        //Then
+        Assertions.assertThrows(NoSuchPostException.class, ()
+                -> purchaseService.purchasePost("buyer", 100L)); //When
+
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #156 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- Post 엔티티에 isPurchasable 필드를 추가했습니다. 
   - isPurchasable가 false일 경우, 구매가 불가합니다.
   - 추후 구매 비활성화 API를 구현 할 예정입니다.
   
- 제보구매 기능을 구현했습니다.  

  - 무료 제보를 구매할 경우:
    - 제보 구매가 정상적으로 구매됩니다.
    
  - 공개 제보를 구매할 경우:
    - 제보 가격이 잔액보다 많을 경우 구매되지 않습니다.
    
  - 단독 제보를 구매할 경우:
    - 제보 가격이 잔액보다 많을 경우 구매되지 않습니다.
    - 이미 팔린 단독 제보일 경우 구매되지 않습니다. 

-  TransactionService에 purchasePostTransaction 메서드를 추가했습니다.
  -  무료 제보를 구매했을 경우, Transaction 엔티티가 생성되지 않습니다. 금전적 거래가 없기 때문입니다.
  -  유료 제보를 (단독/공개) 구매했을 경우, 구매자의 Transaction 엔티티와 판매자의 Transaction 엔티티가 생성됩니다.

- MediaServiceTest의 롤백을 지웠습니다. (죄송합니다 ㅠㅠ)

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 입출금 내역 조회 기능을 구현하겠습니다.
- 구매제한 실행/취소 기능을 구현하겠습니다.
