### PR TITLE
feat: implement searching reply comment API

### DIFF
--- a/src/main/java/com/dope/breaking/api/CommentAPI.java
+++ b/src/main/java/com/dope/breaking/api/CommentAPI.java
@@ -57,6 +57,31 @@ public class CommentAPI {
 
     }
 
+    @GetMapping("/post/comment/{commentId}/reply")
+    public ResponseEntity<List<CommentResponseDto>> getReplyFromComment(
+            Principal principal,
+            @PathVariable Long commentId,
+            @RequestParam(value="cursor") Long cursor,
+            @RequestParam(value="size") Long size
+    ) {
+
+        String username = null;
+        if(principal != null)  {
+            username = principal.getName();
+        }
+
+        SearchCommentConditionDto searchCommentConditionDto = SearchCommentConditionDto.builder()
+                .targetType(CommentTargetType.COMMENT)
+                .targetId(commentId)
+                .cursorId(cursor)
+                .size(size)
+                .build();
+
+        List<CommentResponseDto> result = commentService.getCommentList(searchCommentConditionDto, username);
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/post/comment/{commentId}/reply")
     public ResponseEntity addReply(@PathVariable Long commentId,

--- a/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
@@ -83,6 +83,8 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
         switch (targetType) {
             case POST:
                 return comment.post.id.eq(targetId);
+            case COMMENT:
+                return comment.parent.id.eq(targetId);
         }
         return null;
     }

--- a/src/main/java/com/dope/breaking/service/CommentService.java
+++ b/src/main/java/com/dope/breaking/service/CommentService.java
@@ -107,6 +107,10 @@ public class CommentService {
                 if(!postRepository.existsById(searchCommentConditionDto.getTargetId())) {
                     throw new NoSuchPostException();
                 }
+            case COMMENT:
+                if(!commentRepository.existsById(searchCommentConditionDto.getTargetId())) {
+                    throw new NoSuchCommentException();
+                }
         }
 
         return commentRepository.searchCommentList(me, searchCommentConditionDto);

--- a/src/test/java/com/dope/breaking/service/CommentServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/CommentServiceTest.java
@@ -4,6 +4,7 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.comment.SearchCommentConditionDto;
+import com.dope.breaking.exception.comment.NoSuchCommentException;
 import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.repository.*;
 import org.junit.jupiter.api.DisplayName;
@@ -323,7 +324,7 @@ class CommentServiceTest {
 
     }
 
-    @DisplayName("존재하지 않은 post id가 들어오면, 예외가 발생한다.")
+    @DisplayName("존재하지 않은 post id가 입력되면, 예외가 발생한다.")
     @Test
     void getCommentListFailure() {
         User user = User.builder()
@@ -339,6 +340,26 @@ class CommentServiceTest {
                 .targetId(999L)
                 .build();
         assertThrows(NoSuchPostException.class,
+                () -> commentService.getCommentList(searchCommentConditionDto, "12345g"));
+
+    }
+
+    @DisplayName("존재하지 않은 parent comment id가 입력되면, 예외가 발생한다.")
+    @Test
+    void getReplyCommentListFailure() {
+        User user = User.builder()
+                .username("12345g")
+                .build();
+        userRepository.save(user);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        SearchCommentConditionDto searchCommentConditionDto = SearchCommentConditionDto.builder()
+                .targetType(CommentTargetType.COMMENT)
+                .targetId(999L)
+                .build();
+        assertThrows(NoSuchCommentException.class,
                 () -> commentService.getCommentList(searchCommentConditionDto, "12345g"));
 
     }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #157 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
대댓글 페이징 조회 기능을 구현하였습니다.
기존 댓글 페이징 기능을 재활용하여, 동적쿼리를 통해 비슷하게 동작합니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/181907837-db5bc9c1-1b86-497c-8269-b2798b4e5b41.png)
![image](https://user-images.githubusercontent.com/76773202/181907845-8ce8e440-ba4c-40dd-b168-2c0012eb8224.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
이번 PR이 간단해서, TDD 맛보기를 진행했습니다.
![image](https://user-images.githubusercontent.com/76773202/181907903-84c18211-3d31-4310-96bb-9bea61f2d688.png)

1. 각 계층의 성공/실패 테스트코드 작성
2. repsotiry 구현 후 테스트
3. service 구현 후 테스트
4. API 구현 후 테스트(postman으로 진행)

현재 저희가 사용하고 있는 테스트 방식이, 사실 적합하지 않은 방식이라 제가 조금 더 공부해서 공유하겠습니다.
