### PR TITLE
fix: change type of isFollowing field to Boolean

### DIFF
--- a/src/main/java/com/dope/breaking/dto/user/ProfileInformationResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/ProfileInformationResponseDto.java
@@ -27,11 +27,10 @@ public class ProfileInformationResponseDto {
     int followerCount;
 
     int followingCount;
-
-    boolean isFollowing;
+    Boolean isFollowing;
 
     @Builder
-    public ProfileInformationResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followerCount, int followingCount, boolean isFollowing) {
+    public ProfileInformationResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followerCount, int followingCount, Boolean isFollowing) {
         this.userId = userId;
         this.profileImgURL = profileImgURL;
         this.nickname = nickname;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #163 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
primitive type인 boolean을 사용하여 is- 를 통해 변수명을 선언하면, json으로 변환 시에 is가 사라지는 버그가 있습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/76773202/182157005-cba3eef2-d835-4240-a8d8-aef2f9972092.png)

## 기타
이를 위한 해결 방법은,
- Class type인 Boolean으로 선언한다
-  @JsonProperty 어노테이션을 붙여서 해결한다.

일단 첫번째 방법을 사용했습니다.
추후에 테스트를 작성하거나 할 일이 있을때, null이 허용되면 아무래도 편리할거라는 생각이 듭니다.
(물론 테스트는 테스트일뿐, 실제 운영에서는 null 허용을 해서는 안되는 필드도 있겠지요)