### PR TITLE
refactor: add "isfollowing" field to user lists

### DIFF
--- a/src/main/java/com/dope/breaking/api/CommentLikeAPI.java
+++ b/src/main/java/com/dope/breaking/api/CommentLikeAPI.java
@@ -36,9 +36,9 @@ public class CommentLikeAPI {
     }
 
     @GetMapping("/post/comment/{commentId}/like-list")
-    public ResponseEntity<List<ForListInfoResponseDto>> commentLikedUserList (@PathVariable Long commentId){
+    public ResponseEntity<List<ForListInfoResponseDto>> commentLikedUserList(Principal principal, @PathVariable Long commentId){
 
-        return ResponseEntity.ok().body(commentLikeService.commentLikeList(commentId));
+        return ResponseEntity.ok().body(commentLikeService.commentLikeList(principal,commentId));
 
     }
 

--- a/src/main/java/com/dope/breaking/api/PostLikeAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostLikeAPI.java
@@ -32,8 +32,8 @@ public class PostLikeAPI {
     }
 
     @GetMapping("post/{postId}/like-list")
-    public ResponseEntity<List<ForListInfoResponseDto>> likedUserList (@PathVariable Long postId){
-        return ResponseEntity.ok().body(postLikeService.likedUserList(postId));
+    public ResponseEntity<List<ForListInfoResponseDto>> likedUserList (Principal principal, @PathVariable Long postId){
+        return ResponseEntity.ok().body(postLikeService.likedUserList(principal, postId));
     }
 
 }

--- a/src/main/java/com/dope/breaking/api/RelationshipAPI.java
+++ b/src/main/java/com/dope/breaking/api/RelationshipAPI.java
@@ -24,7 +24,7 @@ public class RelationshipAPI {
     @PostMapping("/follow/{userId}")
     public ResponseEntity followUser( Principal principal, @PathVariable Long userId) {
 
-       followService.followUser(principal.getName(),userId);
+       followService.follow(principal.getName(),userId);
        return ResponseEntity.status(HttpStatus.CREATED).build();
 
     }
@@ -33,22 +33,22 @@ public class RelationshipAPI {
     @DeleteMapping("/follow/{userId}")
     public ResponseEntity unfollowUser(Principal principal, @PathVariable Long userId) {
 
-       followService.unfollowUser(principal.getName(),userId);
+       followService.unfollow(principal.getName(),userId);
        return ResponseEntity.ok().build();
 
     }
 
     @GetMapping("/follow/following/{userId}")
-    public ResponseEntity<List<ForListInfoResponseDto>>followingUsers (@PathVariable Long userId) {
+    public ResponseEntity<List<ForListInfoResponseDto>>followingUsers (Principal principal, @PathVariable Long userId) {
 
-        return ResponseEntity.ok().body(followService.followingUsers(userId));
+        return ResponseEntity.ok().body(followService.followingUsers(principal, userId));
 
     }
 
     @GetMapping("/follow/follower/{userId}")
-    public ResponseEntity<List<ForListInfoResponseDto>> followerUsers (@PathVariable Long userId){
+    public ResponseEntity<List<ForListInfoResponseDto>> followerUsers (Principal principal, @PathVariable Long userId){
 
-        return ResponseEntity.ok().body(followService.followerUsers(userId));
+        return ResponseEntity.ok().body(followService.followerUsers(principal,userId));
 
     }
 

--- a/src/main/java/com/dope/breaking/domain/user/Follow.java
+++ b/src/main/java/com/dope/breaking/domain/user/Follow.java
@@ -3,7 +3,10 @@ package com.dope.breaking.domain.user;
 
 
 
+import lombok.Builder;
 import lombok.Getter;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -16,20 +19,20 @@ public class Follow {
     @Column(name="FOLLOW_ID")
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn (name = "FOLLOWING_USER_ID")
     private User following;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn (name = "FOLLOWED_USER_ID")
     private User followed;
 
-    public void updateFollowing(User user){
-        this.following = user;
-    }
-
-    public void updateFollowed(User following){
-        this.followed = following;
+    @Builder
+    public Follow(User following, User followed){
+        this.following = following;
+        this.followed = followed;
     }
 
 }

--- a/src/main/java/com/dope/breaking/domain/user/Follow.java
+++ b/src/main/java/com/dope/breaking/domain/user/Follow.java
@@ -1,10 +1,8 @@
 package com.dope.breaking.domain.user;
 
-
-
-
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
@@ -12,6 +10,7 @@ import javax.persistence.*;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class Follow {
 
     @Id

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -26,11 +26,11 @@ public class User {
     private List<Post> postList = new ArrayList<Post>();
 
     //유저가 팔로잉하는 유저리스트
-    @OneToMany(mappedBy = "following", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "following")
     private List<Follow> followingList = new ArrayList<Follow>();
 
     //유저를 팔로우하는 유저리스트
-    @OneToMany(mappedBy = "followed", orphanRemoval = true)
+    @OneToMany(mappedBy = "followed")
     private List<Follow> followerList = new ArrayList<Follow>();
 
     //유저가 차단한 리스트

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -1,7 +1,6 @@
 package com.dope.breaking.domain.user;
 
 import com.dope.breaking.domain.financial.Purchase;
-import com.dope.breaking.domain.financial.Statement;
 import com.dope.breaking.domain.post.Post;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dope/breaking/dto/user/ForListInfoResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/ForListInfoResponseDto.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.dto.user;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
@@ -11,5 +12,7 @@ public class ForListInfoResponseDto {
     private String nickname;
     private String statusMsg;
     private String profileImgURL;
+    @JsonProperty(value = "isFollowing")
+    private boolean isFollowing = false;
 
 }

--- a/src/main/java/com/dope/breaking/repository/FollowRepository.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepository.java
@@ -5,6 +5,8 @@ import com.dope.breaking.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
+
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     //팔로워 수
@@ -14,5 +16,11 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
     int countFollowsByFollowed(User user);
 
     boolean existsFollowsByFollowedAndFollowing(User followed, User following);
+
+    void deleteByFollowedAndFollowing(User followed, User following);
+
+    List<Follow> findAllByFollowing(User following);
+
+    List<Follow> findAllByFollowed(User followed);
 
 }

--- a/src/main/java/com/dope/breaking/service/CommentLikeService.java
+++ b/src/main/java/com/dope/breaking/service/CommentLikeService.java
@@ -2,19 +2,23 @@ package com.dope.breaking.service;
 
 import com.dope.breaking.domain.comment.Comment;
 import com.dope.breaking.domain.comment.CommentLike;
+import com.dope.breaking.domain.user.Follow;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.user.ForListInfoResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.comment.NoSuchCommentException;
 import com.dope.breaking.exception.like.AlreadyLikedException;
 import com.dope.breaking.exception.like.AlreadyUnlikedException;
+import com.dope.breaking.exception.user.NoSuchUserException;
 import com.dope.breaking.repository.CommentLikeRepository;
 import com.dope.breaking.repository.CommentRepository;
+import com.dope.breaking.repository.FollowRepository;
 import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +29,7 @@ public class CommentLikeService {
     private final CommentLikeRepository commentLikeRepository;
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
+    private final FollowRepository followRepository;
 
     @Transactional
     public void likeComment (String username, Long commentId){
@@ -56,17 +61,28 @@ public class CommentLikeService {
     }
 
     @Transactional
-    public List<ForListInfoResponseDto> commentLikeList (Long commentId) {
+    public List<ForListInfoResponseDto> commentLikeList (Principal principal, Long commentId) {
 
         Comment comment = commentRepository.findById(commentId).orElseThrow(NoSuchCommentException::new);
 
         List<CommentLike> commentLikeList= commentLikeRepository.findAllByComment(comment);
         List<ForListInfoResponseDto> forListInfoResponseDtoList = new ArrayList<>();
 
-        for (CommentLike commentLike : commentLikeList) {
-            User user = commentLike.getUser();
-            forListInfoResponseDtoList.add(new ForListInfoResponseDto(user.getId(),user.getNickname(),user.getStatusMsg(),user.getCompressedProfileImgURL()));
+        if(principal == null){
+            for (CommentLike commentLike : commentLikeList) {
+                User likedUser = commentLike.getUser();
+                forListInfoResponseDtoList.add(new ForListInfoResponseDto(likedUser.getId(),likedUser.getNickname(),likedUser.getStatusMsg(),likedUser.getCompressedProfileImgURL(),false));
+            }
         }
+        else{
+            User user = userRepository.findByUsername(principal.getName()).orElseThrow(InvalidAccessTokenException::new);
+            for (CommentLike commentLike : commentLikeList) {
+                User likedUser = commentLike.getUser();
+                boolean isFollowing = followRepository.existsFollowsByFollowedAndFollowing(likedUser,user);
+                forListInfoResponseDtoList.add(new ForListInfoResponseDto(likedUser.getId(),likedUser.getNickname(),likedUser.getStatusMsg(),likedUser.getCompressedProfileImgURL(),isFollowing));
+            }
+        }
+
 
         return forListInfoResponseDtoList;
 

--- a/src/test/java/com/dope/breaking/api/CommentLikeAPITest.java
+++ b/src/test/java/com/dope/breaking/api/CommentLikeAPITest.java
@@ -10,6 +10,7 @@ import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
 import com.dope.breaking.service.CommentLikeService;
 import com.dope.breaking.service.CommentService;
+import com.dope.breaking.service.FollowService;
 import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -60,6 +61,9 @@ class CommentLikeAPITest {
 
     @Autowired
     private CommentService commentService;
+
+    @Autowired
+    private FollowService followService;
 
     @Autowired
     private EntityManager entityManager;
@@ -174,6 +178,7 @@ class CommentLikeAPITest {
 
     @DisplayName("세명의 유저가 댓글에 좋아요를 누른 경우, 리턴 된 리스트는 두명의 정보를 담는다.")
     @Transactional
+    @WithMockCustomUser
     @Test
     void commentLikeList() throws Exception {
 
@@ -198,12 +203,17 @@ class CommentLikeAPITest {
         commentLikeRepository.save(commentLike2);
         commentLikeRepository.save(commentLike3);
 
+        followService.follow("12345g",user2.getId());
+
         entityManager.flush();
         entityManager.clear();
 
         //When
         this.mockMvc.perform(get("/post/comment/{commentId}/like-list",commentId))
                 .andExpect(status().isOk()) //Then
+                .andExpect(jsonPath("$[0].isFollowing").value(false))
+                .andExpect(jsonPath("$[1].isFollowing").value(true))
+                .andExpect(jsonPath("$[2].isFollowing").value(false))
                 .andExpect(jsonPath("$", hasSize(3)));
 
     }

--- a/src/test/java/com/dope/breaking/api/PostLikeAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostLikeAPITest.java
@@ -6,6 +6,7 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.repository.PostLikeRepository;
 import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.service.FollowService;
 import com.dope.breaking.service.PostLikeService;
 import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
 import org.assertj.core.api.Assertions;
@@ -52,6 +53,9 @@ class PostLikeAPITest {
     @Autowired
     private PostRepository postRepository;
 
+    @Autowired
+    private FollowService followService;
+
     @BeforeEach //DB에 유저정보를 먼저 저장.
     public void createUserInfo() {
 
@@ -65,11 +69,6 @@ class PostLikeAPITest {
 
     }
 
-    @AfterEach
-    public void afterCleanUp() {
-        userRepository.deleteAll();
-        postRepository.deleteAll();
-    }
 
     @WithMockCustomUser
     @Test
@@ -137,6 +136,7 @@ class PostLikeAPITest {
     }
 
     @Test
+    @WithMockCustomUser
     void likedUserList() throws Exception{
 
         //Given
@@ -151,9 +151,13 @@ class PostLikeAPITest {
         postLikeService.likePost(user1,post);
         postLikeService.likePost(user2,post);
 
+        followService.follow("12345g",user1.getId());
+
         //When
         this.mockMvc.perform(get("/post/{postId}/like-list",post.getId()))
                 .andExpect(status().isOk()) //Then
+                .andExpect(jsonPath("$[0].isFollowing").value(true))
+                .andExpect(jsonPath("$[1].isFollowing").value(false))
                 .andExpect(jsonPath("$", hasSize(2)));
     }
 

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -23,7 +23,6 @@ class FollowRepositoryTest {
 
     @Autowired UserRepository userRepository;
     @Autowired FollowRepository followRepository;
-    @Autowired EntityManager em;
 
     @BeforeEach //DB에 유저정보를 먼저 저장.
     public void createUserInfo() {

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -76,22 +76,11 @@ class FollowRepositoryTest {
         );
         userRepository.save(follower2);
 
-        Follow follow1 = new Follow();
+        Follow follow1 = new Follow(hero,follower1);
+        Follow follow2 = new Follow(hero,follower2);
 
-        follow1.updateFollowing(hero);
-        follow1.updateFollowed(follower1);
-        follower1.getFollowingList().add(follow1);
-        hero.getFollowerList().add(follow1);
-
-        // ==================
-
-        Follow follow2 = new Follow();
-
-        follow2.updateFollowing(hero);
-        follow2.updateFollowed(follower2);
-
-        follower2.getFollowingList().add(follow2);
-        hero.getFollowerList().add(follow2);
+        followRepository.save(follow1);
+        followRepository.save(follow2);
 
     }
 

--- a/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
@@ -145,7 +145,7 @@ class PostLikeServiceTest {
         postLikeService.likePost(user2,post);
 
         //Then
-        Assertions.assertThat(postLikeService.likedUserList(post.getId()).size()).isEqualTo(2);
+        Assertions.assertThat(postLikeService.likedUserList(null,post.getId()).size()).isEqualTo(2);
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #161 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- followService 관련 기능을 대대적으로 리펙토링 했습니다.
- 팔로우/팔로잉 리스트, 포스트 좋아요 한 사람 리스트, 그리고 댓글 좋아요 한 사람 리스트에 모두 "isFollowing" 필드를 추가했습니다:
  - 로그인 한 유저일 경우, 팔로우 여부를 판단하여 리턴합니다.
  - 로그인 하지 않은 유저일 경우, 팔로우 여부는 일괄적으로 "false"처리합니다.
- 이에 맞게 API와 테스트코드를 수정했습니다.  
- 노션의 api 시트를 수정했습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
MockMvc 테스트코드 관련해서 필드값 확인하는 방법을 공유합니다. 도움이 되길 바랍니다.

<img width="727" alt="스크린샷 2022-08-02 오전 2 16 48" src="https://user-images.githubusercontent.com/87322089/182207033-a6a50a81-cd3d-4dde-a6de-a93cb94ecc98.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 명단 관련 리펙토링을 하는 김에 FollowService까지 같이 하게 되었습니다. 
- 웬만하면 각기 다른 PR에 올리고 싶었지만, 하다보니 FollowService가 수정이 되어야 리펙토링이 되어야 명단 관련 리펙토링이 가능하단 걸 알게되었습니다. (물론 "그렇다면 FollowService부터 먼저 따로 PR날리면 되지 않느냐" 묻는다면 달리 할 말을 없습니다)
- 최대한 PR를 쪼개도록 주의하겠습니다. 

- 구매자 리스트 & 거래 내역 구현을 시작하겠습니다