### PR TITLE
feat: refactor JwtAuthenticationFilter Exception

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -37,7 +37,7 @@ public class PostAPI {
     public ResponseEntity<Map<String, Long>> postModify(@PathVariable("postId") long postId, Principal principal, @RequestBody PostRequestDto postRequestDto) throws Exception {
         postService.modify(postId , principal.getName(), postRequestDto);
         Map<String, Long> result = new LinkedHashMap<>();
-        result.put("Modified postId", postId);
+        result.put("postId", postId);
         return ResponseEntity.status(HttpStatus.OK).body(result);
     }
 

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -27,8 +27,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL("BSE415", "사용중인 이메일입니다."),
     ALREADY_FOLLOWING("BSE420","이미 팔로우 중인 유저입니다."),
     ALREADY_UNFOLLOWING("BSE421","이미 언팔로우 중인 유저입니다."),
-    NO_SUCH_POST("BSE450","해당 제보를 찾을 수 없습니다"),
-    NO_SUCH_COMMENT("BSE451","해당 댓글을 찾을 수 없습니다"),
+    NO_SUCH_POST("BSE450","해당 제보를 찾을 수 없습니다."),
+    NO_SUCH_COMMENT("BSE451","해당 댓글을 찾을 수 없습니다."),
     PURCHASED_POST("BSE452", "판매된 게시글은 삭제할 수 없습니다."),
 
     ALREADY_BOOKMARKED("BSE456", "이미 북마크를 선택했습니다."),

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
@@ -59,7 +59,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/user/**").hasRole("USER") //USER를 가진 권한만이 접근이 허용됨
                 .antMatchers("/**").permitAll() //그외 접근은 모두 허용됨.
                 .and()
-                .exceptionHandling().authenticationEntryPoint(jwtEntryPoint()); //에러코드 반환할 except
+                .exceptionHandling().authenticationEntryPoint(jwtEntryPoint()); //에러코드 반환할 ExceptionPoint
 
 
         http.addFilterBefore(jwtAuthenticationFilter(),
@@ -76,7 +76,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService, redisService );
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService);
         return jwtAuthenticationFilter;
     }
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtAuthenticationFilter.java
@@ -2,11 +2,9 @@ package com.dope.breaking.security.jwt;
 
 import com.dope.breaking.security.userDetails.PrincipalDetailsService;
 import com.dope.breaking.service.RedisService;
-import com.dope.breaking.service.UserService;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.JSONObject;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
@@ -20,8 +18,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -30,19 +27,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//모든 서�
 
     private final PrincipalDetailsService principalDetailsService;
 
-    private final RedisService redisService;
 
-
-    //인증작업을 실시함.
     @Override
     public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         if(request.getRequestURI().equals("/reissue")) {
-            filterChain.doFilter(request, response); // GET: /reissue의 요청이라면 밑의 로직을 무시하고 Controller단까지 진입.
+            filterChain.doFilter(request, response);
             return;
         }
 
         String accessToken = jwtTokenProvider.extractAccessToken(request).orElse(null);
-
 
         if (accessToken != null && jwtTokenProvider.validateToken(accessToken) == true) {
 
@@ -55,18 +48,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {//모든 서�
                 context.setAuthentication(authentication);
                 SecurityContextHolder.setContext(context);
             }catch (UsernameNotFoundException e){
-                log.info("유저 정보 없음");
-                request.setAttribute("exception", "유저 정보를 찾을 수 없음");
+                request.setAttribute("exception", "UsernameNotFoundException"); //유저 정보를 찾을 수 없다는 에러.
             }
         } else if (accessToken != null && jwtTokenProvider.validateToken(accessToken) == false) {
             try {
                 String username = jwtTokenProvider.getUsername(accessToken);
             } catch (ExpiredJwtException e) {
-                log.info("Expiraion date");
-                request.setAttribute("exception", "Access Token이 만료되었습니다.");
+                request.setAttribute("exception", "ExpiredJwtException"); //만료 에러.
             } catch (SecurityException | IllegalArgumentException | JwtException e) {
-                log.info("invalid sign");
-                request.setAttribute("exception", "Access Token이 유효하지 않습니다.");
+                request.setAttribute("exception", "AccessJwtException"); //유효하지 않은 예외.
             }
         }
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
@@ -1,10 +1,10 @@
 package com.dope.breaking.security.jwt;
 
+import com.dope.breaking.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,35 +18,44 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
     public void commence(HttpServletRequest request, HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        String exception = (String) request.getAttribute("exception");
 
-        //jwt 없이 접급하려고 할때.
-        if(authException instanceof InsufficientAuthenticationException){
-            if (exception != null) {
-                setResponse(response, exception);
-            }
-            else {
-                JSONObject responseJson = new JSONObject();
-                response.setContentType("application/json;charset=UTF-8");
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                responseJson.put("message", "로그인이 필요합니다.");
-
-                response.getWriter().print(responseJson);
-            }
+        String exceptionInfo = (String) request.getAttribute("exception");
+        //JwtAuthenticationFilter에서 전달받은 예외 내용
+        if (exceptionInfo != null) {
+            setException(response, exceptionInfo);
         }
-
-        else if (exception != null) {
-            setResponse(response, exception);
+        //PreAuthorize 어노테이션에 의한 예외
+        else if (authException instanceof InsufficientAuthenticationException) {
+            exceptionInfo = "InsufficientAuthenticationException";
+            setException(response, exceptionInfo);
         }
     }
 
-    private void setResponse(HttpServletResponse response, String exception) throws IOException {
+    private void setException(HttpServletResponse response, String exceptionInfo) throws IOException {
+        final String errorCode;
+        final String message;
+        if (exceptionInfo.equals("UsernameNotFoundException")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            setResponse(response, ErrorCode.NO_SUCH_USER.getCode(), ErrorCode.NO_SUCH_USER.getMessage());
+        } else if (exceptionInfo.equals("ExpiredJwtException")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            setResponse(response, ErrorCode.EXPIRED_ACCESS_TOKEN.getCode(), ErrorCode.EXPIRED_ACCESS_TOKEN.getMessage());
+        } else if (exceptionInfo.equals("AccessJwtException")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            setResponse(response, ErrorCode.INVALID_ACCESS_TOKEN.getCode(), ErrorCode.INVALID_ACCESS_TOKEN.getMessage());
+        } else if( exceptionInfo.equals("InsufficientAuthenticationException")){
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            setResponse(response, ErrorCode.REQUIRE_LOGIN.getCode(),ErrorCode.REQUIRE_LOGIN.getMessage() );
+        }
+    }
+
+
+    private void setResponse(HttpServletResponse response, String errorCode, String message) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-
+        response.setStatus(response.getStatus());
         JSONObject responseJson = new JSONObject();
-        responseJson.put("message", exception);
-
+        responseJson.put("code", errorCode);
+        responseJson.put("message", message);
         response.getWriter().print(responseJson);
     }
 }

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -19,19 +19,17 @@ import java.util.*;
 public class JwtTokenProvider {
 
     @Value("${jwt.secret}")
-    private  String secret;
+    private String secret;
 
     private final String accessHeader = "Authorization";
     private final String refreshHeader = "Authorization-Refresh";
 
     private static final String BEARER = "Bearer ";
 
-    private final long accesstokenValidityInMilliseconds = 604800 *  1000L; //엑세스 토큰 유효기간 1주
+    private final long accesstokenValidityInMilliseconds = 604800 * 1000L; //엑세스 토큰 유효기간 1주
     private final long refreshtokenValidityInMilliseconds = 2 * 604800 * 1000L; //리플리쉬 토큰 유효기간 2주
 
-    private final UserRepository userRepository;
 
-    // JWT 토큰 생성
     @PostConstruct
     protected void init() {
         secret = Base64.getEncoder().encodeToString(secret.getBytes());
@@ -49,7 +47,7 @@ public class JwtTokenProvider {
                 .compact(); //토큰생성
     }
 
-    public String createRefreshToken(String username){
+    public String createRefreshToken(String username) {
         Claims claims = Jwts.claims().setSubject(username); // JWT payload 에 저장되는 정보단위
         Date now = new Date();
         return Jwts.builder().setSubject("RefreshToken")
@@ -66,13 +64,18 @@ public class JwtTokenProvider {
     }
 
 
-    public Optional<String> extractAccessToken(String request) throws IOException{
+    public Optional<String> extractAccessToken(String request) throws IOException {
         return Optional.ofNullable(request).filter(refreshToken -> refreshToken.startsWith(BEARER)).map(refreshToken -> refreshToken.replace(BEARER, ""));
     }
 
 
-    public Optional<String> extractRefreshToken(String request) throws IOException{
+    public Optional<String> extractRefreshToken(String request) throws IOException {
         return Optional.ofNullable(request).filter(refreshToken -> refreshToken.startsWith(BEARER)).map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+
+    public Long getExpireTime(String token) {
+        return Jwts.claims().getExpiration().getTime();
     }
 
 
@@ -86,7 +89,7 @@ public class JwtTokenProvider {
         try {
             Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
             return true;
-        }  catch (SignatureException  | MalformedJwtException e) {
+        } catch (SignatureException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
             log.info("만료된 JWT 토큰입니다.");
@@ -94,7 +97,7 @@ public class JwtTokenProvider {
             log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
             log.info("JWT 토큰이 잘못되었습니다.");
-        }catch(Exception e){
+        } catch (Exception e) {
             log.info("JWT에 알 수 없는 문제가 발생하였습니다");
         }
         return false;

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -1,7 +1,10 @@
 package com.dope.breaking.service;
 
+import com.dope.breaking.exception.auth.ExpiredRefreshTokenException;
 import com.dope.breaking.exception.auth.InvalidRefreshTokenException;
 import com.dope.breaking.security.jwt.JwtTokenProvider;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -20,23 +23,25 @@ public class JwtAuthenticationService {
 
     private final RedisService redisService;
 
-
-
     public ResponseEntity<?> reissue(String accessToken, String refreshToken) throws IOException {
 
         String getAccessToken = jwtTokenProvider.extractAccessToken(accessToken).orElse(null);
         String getRefreshToken = jwtTokenProvider.extractRefreshToken(refreshToken).orElse(null);
-        log.info(Boolean.toString(jwtTokenProvider.validateToken(getRefreshToken)));
 
-        if (refreshToken != null && jwtTokenProvider.validateToken(getRefreshToken) == false) { //리플리쉬 토큰이 있고, 유효하지 않다면?
-            throw new InvalidRefreshTokenException();
-        }
-        else if(getAccessToken != null && jwtTokenProvider.validateToken(getRefreshToken) == true){
+        if (refreshToken != null && jwtTokenProvider.validateToken(getRefreshToken) == false) {
+            try {
+                String username = jwtTokenProvider.getUsername(accessToken);
+            } catch (ExpiredJwtException e) {
+               throw new ExpiredRefreshTokenException(); //만료 에러.
+            } catch (SecurityException | IllegalArgumentException | JwtException e) {
+               throw new InvalidRefreshTokenException(); //유효하지 않은 예외.
+            }
+        } else if (getAccessToken != null && jwtTokenProvider.validateToken(getRefreshToken) == true) {
             String username = jwtTokenProvider.getUsername(getRefreshToken);
             log.info(username);
             String redisRefreshToken = redisService.getData(username);
             log.info(redisRefreshToken);
-            if(!getRefreshToken.equals(redisRefreshToken)){
+            if (!getRefreshToken.equals(redisRefreshToken)) { //Redis에 저장된 Refresh토큰이 존재하지 않을 때.
                 throw new InvalidRefreshTokenException();
             }
 
@@ -44,7 +49,7 @@ public class JwtAuthenticationService {
             httpHeaders.set("Authorization", jwtTokenProvider.createAccessToken(username));
             String newRefrsehToken = jwtTokenProvider.createRefreshToken(username);
             httpHeaders.set("Authorization-Refresh", newRefrsehToken);
-            redisService.setDataWithExpiration(username, newRefrsehToken, 2 * 604800L );
+            redisService.setDataWithExpiration(username, newRefrsehToken, 2 * 604800L);
 
             return ResponseEntity.status(HttpStatus.OK).headers(httpHeaders).build();
         }

--- a/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
@@ -71,6 +71,8 @@ class JwtAuthenticationFilterTest {
     private static String USERNAME = "";
     private static String PASSWORD = "123456789";
 
+    private static String accesstoken = "";
+
     static String accessjwt;
     static String refreshjwt;
 
@@ -83,7 +85,7 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
+
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -103,7 +105,7 @@ class JwtAuthenticationFilterTest {
         accessjwt = (String) response.getHeaderValue("Authorization");
         System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
         refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
-        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+        System.out.println("user refreshtoken : " + redisService.getData(USERNAME));
 
         redisService.deleteValues(USERNAME);
     }
@@ -125,7 +127,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -165,7 +166,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -203,7 +203,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -247,7 +246,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -295,7 +293,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -336,7 +333,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -376,8 +372,6 @@ class JwtAuthenticationFilterTest {
 
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
-
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -426,8 +420,6 @@ class JwtAuthenticationFilterTest {
     void reissueWithValidTokens() throws Exception {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
-
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -476,7 +468,6 @@ class JwtAuthenticationFilterTest {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);
@@ -509,14 +500,12 @@ class JwtAuthenticationFilterTest {
 
     }
 
-    @DisplayName("유효하지 않은 엑세스 토큰과 유효한 리플리시 토큰으로 재발행을 요청하면 정상적으로 재발행된다. ")
+    @DisplayName("유효하지 않은 엑세스 토큰과 유효한 리플리시 토큰으로 재발행을 요청하면 정상적으로 재발행된다.")
     @Transactional
     @Test
     void reissueWithInvalidAccessButValidRefrsh() throws Exception {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
-
-        String accesstoken = "";
         Map<String, String> info = new LinkedHashMap<>();
 
         info.put("accessToken", accesstoken);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #127 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 기존의 JwtAuthenticationFilter에서는 4가지의 예외를 처리했습니다.
 a. 인증되지 않은 유저가 접근할 시 요청을 거부하는 예외
 b. jwt토큰으로 요청하였지만, jwt에 담긴 username이 db에 존재하지 않을 때 발생하는 예외
 c. AccessToken이 만료되었을 때 반환하는 예외
 d. AccessToken이 유효하지 않을 떄 반환하는 예외

기존에는 단일 메시지만 던져주어 클라이언트과 규약한 code를 반환하지 않았습니다. 하지만, 이번 리팩토링을 통해 약속된 code 및 message를 반환합니다. 따라서 반환하는 code와 message는 다음과 같습니다.
 a. 인증되지 않은 유저가 접근할 시 요청을 거부하는 예외
("BSE000", "로그인이 필요합니다.")
 b. jwt토큰으로 요청하였지만, jwt에 담긴 username이 db에 존재하지 않을 때 발생하는 예외
("BSE401", "해당 유저를 찾을 수 없습니다.")
 c. AccessToken이 만료되었을 때 반환하는 예외
("BSE002", "Access Token이 만료되었습니다.")
 d. AccessToken이 유효하지 않을 떄 반환하는 예외
("BSE001", "Access Token이 유효하지 않습니다.")

2. 다음으로 재발행의 예외처리를 리팩토링하였습니다.   
  기존에는 만료에 대한 예외가 없었으나 이번에 추가하였습니다.

3. ErrorCode에서 누락된 마침표('.')가 존재하였기에 통일성을 위해 '.'을 추가해주었습니다.
## 이미지
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="857" alt="스크린샷 2022-08-02 오후 1 41 22" src="https://user-images.githubusercontent.com/62254434/182296106-ee2dbae7-c357-47a2-9899-efc823defc3f.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
로그아웃 기능을 추가로 구현합니다.