### PR TITLE
feat: add transaction list method

### DIFF
--- a/src/main/java/com/dope/breaking/api/FinancialAPI.java
+++ b/src/main/java/com/dope/breaking/api/FinancialAPI.java
@@ -2,18 +2,19 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.domain.financial.TransactionType;
 import com.dope.breaking.dto.financial.AmountRequestDto;
+import com.dope.breaking.dto.financial.TransactionResponseDto;
 import com.dope.breaking.service.PurchaseService;
 import com.dope.breaking.service.StatementService;
+import com.dope.breaking.service.TransactionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.security.Principal;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +22,7 @@ public class FinancialAPI {
 
     private final StatementService statementService;
     private final PurchaseService purchaseService;
+    private final TransactionService transactionService;
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/financial/deposit")
@@ -49,4 +51,11 @@ public class FinancialAPI {
 
     }
 
+    @PreAuthorize("isAuthenticated")
+    @GetMapping("/profile/transaction")
+    public ResponseEntity<List<TransactionResponseDto>> transactionList(Principal principal){
+
+        return ResponseEntity.status(HttpStatus.OK).body(transactionService.transactionList(principal.getName()));
+
+    }
 }

--- a/src/main/java/com/dope/breaking/domain/financial/Transaction.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Transaction.java
@@ -1,17 +1,21 @@
 package com.dope.breaking.domain.financial;
 
 
+import com.dope.breaking.domain.baseTimeEntity.BaseTimeEntity;
 import com.dope.breaking.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor
-public class Transaction {
+public class Transaction extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,16 +36,22 @@ public class Transaction {
 
     private int amount;
 
+    private int balance;
+
+    @CreatedDate
+    private LocalDateTime transactionTime;
+
     @Enumerated(EnumType.STRING)
     private TransactionType transactionType;
 
     @Builder
-    public Transaction(User user, Statement statement, Purchase purchase, int amount, TransactionType transactionType){
+    public Transaction(User user, Statement statement, Purchase purchase, int amount, int balance, TransactionType transactionType){
 
         this.user = user;
         this.statement =  statement;
         this.purchase = purchase;
         this.amount = amount;
+        this.balance = balance;
         this.transactionType = transactionType;
 
     }

--- a/src/main/java/com/dope/breaking/domain/financial/TransactionType.java
+++ b/src/main/java/com/dope/breaking/domain/financial/TransactionType.java
@@ -1,5 +1,17 @@
 package com.dope.breaking.domain.financial;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@RequiredArgsConstructor
 public enum TransactionType {
-    DEPOSIT, WITHDRAW, BUY_POST, SELL_POST;
+    DEPOSIT ("deposit"),
+    WITHDRAW("withdraw"),
+    BUY_POST("buy_post"),
+    SELL_POST("sell_post");
+
+    private final String title;
 }

--- a/src/main/java/com/dope/breaking/dto/financial/TransactionResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/financial/TransactionResponseDto.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.dto.financial;
 
+import com.dope.breaking.domain.financial.Transaction;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -15,5 +17,15 @@ public class TransactionResponseDto {
     private String transactionType;
     private int amount;
     private int balance;
+
+    @Builder
+    public TransactionResponseDto (Transaction transaction){
+
+        this.transactionTime = transaction.getTransactionTime();
+        this.transactionType = transaction.getTransactionType().getTitle();
+        this.amount = transaction.getAmount();
+        this.balance = transaction.getBalance();
+
+    }
 
 }

--- a/src/main/java/com/dope/breaking/dto/financial/TransactionResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/financial/TransactionResponseDto.java
@@ -1,0 +1,19 @@
+package com.dope.breaking.dto.financial;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class TransactionResponseDto {
+
+    private LocalDateTime transactionTime;
+    private String transactionType;
+    private int amount;
+    private int balance;
+
+}

--- a/src/main/java/com/dope/breaking/exception/bookmark/AlreadyBookmarkedException.java
+++ b/src/main/java/com/dope/breaking/exception/bookmark/AlreadyBookmarkedException.java
@@ -2,7 +2,6 @@ package com.dope.breaking.exception.bookmark;
 
 import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.ErrorCode;
-import com.dope.breaking.exception.like.AlreadyLikedException;
 import org.springframework.http.HttpStatus;
 
 public class AlreadyBookmarkedException extends BreakingException {

--- a/src/main/java/com/dope/breaking/repository/TransactionRepository.java
+++ b/src/main/java/com/dope/breaking/repository/TransactionRepository.java
@@ -1,7 +1,13 @@
 package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.financial.Transaction;
+import com.dope.breaking.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TransactionRepository extends JpaRepository <Transaction, Long> {
+
+    List<Transaction> findAllByUser(User user);
+    
 }

--- a/src/main/java/com/dope/breaking/repository/TransactionRepository.java
+++ b/src/main/java/com/dope/breaking/repository/TransactionRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface TransactionRepository extends JpaRepository <Transaction, Long> {
 
-    List<Transaction> findAllByUser(User user);
+    List<Transaction> findAllByUserOrderByTransactionTimeDesc(User user);
 
 }

--- a/src/main/java/com/dope/breaking/repository/TransactionRepository.java
+++ b/src/main/java/com/dope/breaking/repository/TransactionRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 public interface TransactionRepository extends JpaRepository <Transaction, Long> {
 
     List<Transaction> findAllByUser(User user);
-    
+
 }

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -5,10 +5,18 @@ import com.dope.breaking.domain.financial.Statement;
 import com.dope.breaking.domain.financial.Transaction;
 import com.dope.breaking.domain.financial.TransactionType;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.financial.TransactionResponseDto;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.user.NoPermissionException;
 import com.dope.breaking.repository.TransactionRepository;
+import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,21 +24,38 @@ import org.springframework.transaction.annotation.Transactional;
 public class TransactionService {
 
     private final TransactionRepository transactionRepository;
+    private final UserRepository userRepository;
 
     public void depositOrWithdrawTransaction(User user, Statement statement){
 
-        Transaction transaction = new Transaction(user, statement,null, statement.getAmount(), statement.getTransactionType());
+        Transaction transaction = new Transaction(user, statement,null, statement.getAmount(), user.getBalance(),statement.getTransactionType());
         transactionRepository.save(transaction);
 
     }
 
     public void purchasePostTransaction(User buyer, User seller, Purchase purchase){
 
-        Transaction buyerTransaction = new Transaction(buyer, null, purchase, purchase.getPrice(), TransactionType.BUY_POST);
-        Transaction sellerTransaction = new Transaction(seller, null, purchase, purchase.getPrice(), TransactionType.SELL_POST);
+        Transaction buyerTransaction = new Transaction(buyer, null, purchase, purchase.getPrice(), buyer.getBalance(), TransactionType.BUY_POST);
+        Transaction sellerTransaction = new Transaction(seller, null, purchase, purchase.getPrice(), seller.getBalance(), TransactionType.SELL_POST);
         transactionRepository.save(buyerTransaction);
         transactionRepository.save(sellerTransaction);
 
+    }
+
+    public List<TransactionResponseDto> transactionList(String username){
+        
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+
+        List<Transaction> transactionList = transactionRepository.findAllByUser(user);
+        List<TransactionResponseDto> transactionResponseDtoList= new ArrayList<>();
+        
+        if(transactionList!=null){
+            Collections.reverse(transactionList);
+            for (Transaction transaction : transactionList) {
+                transactionResponseDtoList.add(new TransactionResponseDto(transaction.getTransactionTime(),transaction.getTransactionType().getTitle(), transaction.getAmount(), transaction.getBalance()));
+            }
+        }
+        return transactionResponseDtoList;
     }
 
 

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -46,17 +47,13 @@ public class TransactionService {
         
         User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
 
-        List<Transaction> transactionList = transactionRepository.findAllByUser(user);
+        List<Transaction> transactionList = transactionRepository.findAllByUserOrderByTransactionTimeDesc(user);
         List<TransactionResponseDto> transactionResponseDtoList= new ArrayList<>();
         
         if(transactionList!=null){
-            Collections.reverse(transactionList);
-            for (Transaction transaction : transactionList) {
-                transactionResponseDtoList.add(new TransactionResponseDto(transaction.getTransactionTime(),transaction.getTransactionType().getTitle(), transaction.getAmount(), transaction.getBalance()));
-            }
+            transactionResponseDtoList = transactionList.stream().map(o -> new TransactionResponseDto(o.getTransactionTime(), o.getTransactionType().getTitle(), o.getAmount(),o.getBalance())).collect(Collectors.toList());
         }
         return transactionResponseDtoList;
     }
-
 
 }

--- a/src/main/java/com/dope/breaking/service/TransactionService.java
+++ b/src/main/java/com/dope/breaking/service/TransactionService.java
@@ -51,7 +51,7 @@ public class TransactionService {
         List<TransactionResponseDto> transactionResponseDtoList= new ArrayList<>();
         
         if(transactionList!=null){
-            transactionResponseDtoList = transactionList.stream().map(o -> new TransactionResponseDto(o.getTransactionTime(), o.getTransactionType().getTitle(), o.getAmount(),o.getBalance())).collect(Collectors.toList());
+            transactionResponseDtoList = transactionList.stream().map(transaction -> new TransactionResponseDto(transaction)).collect(Collectors.toList());
         }
         return transactionResponseDtoList;
     }

--- a/src/test/java/com/dope/breaking/service/TransactionServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/TransactionServiceTest.java
@@ -1,0 +1,130 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.financial.TransactionType;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.financial.TransactionResponseDto;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@Transactional
+class TransactionServiceTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private TransactionService transactionService;
+
+    @Autowired
+    private StatementService statementService;
+
+    @Autowired
+    private PurchaseService purchaseService;
+
+    @Autowired
+    private PostService postService;
+
+
+    @DisplayName("유저네임이 일치할 경우, 입/출금과 제보 구매/판매 내역이 최신순으로 리턴된다.")
+    @Test
+    void transactionList() throws Exception {
+
+        //Given
+        User user1 = new User();
+        user1.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username1", Role.USER);
+        userRepository.save(user1);
+
+        statementService.depositOrWithdraw("username1", 30000, TransactionType.DEPOSIT);
+        statementService.depositOrWithdraw("username1", 10000, TransactionType.WITHDRAW);
+
+
+        User user2 = new User();
+        user2.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username2", Role.USER);
+        user2.updateBalance(0);
+        userRepository.save(user2);
+
+        List<MultipartFile> multipartFiles = new LinkedList<>();
+
+        String json1 = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 10000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"exclusive\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId1 = postService.create("username2", json1, multipartFiles);
+        purchaseService.purchasePost("username1",postId1);
+
+        String json2 = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 5000," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"charged\"," +
+                "\"eventTime\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"region\" : \"abgujung\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345" +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        Long postId2 = postService.create("username1", json2, multipartFiles);
+        purchaseService.purchasePost("username2",postId2);
+
+        //When
+        List<TransactionResponseDto> transactionList = transactionService.transactionList("username1");
+
+        //Then
+        assertEquals("sell_post",transactionList.get(0).getTransactionType());
+        assertEquals("buy_post",transactionList.get(1).getTransactionType());
+        assertEquals("withdraw",transactionList.get(2).getTransactionType());
+        assertEquals("deposit",transactionList.get(3).getTransactionType());
+
+    }
+
+    @DisplayName("아무 입출금 및 거래내역이 없는 경우, 빈 리스트를 반환한다. ")
+    @Test
+    void emptyTransactionList() throws Exception {
+
+        //Given
+        User user1 = new User();
+        user1.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username1", Role.USER);
+        userRepository.save(user1);
+
+        //When
+        List<TransactionResponseDto> transactionList = transactionService.transactionList("username1");
+
+        //Then
+        assertEquals(0, transactionList.size());
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #162 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저의 입출금 및 제보 구매/판매 내역을 최신순으로 리턴하는 기능을 구현했습니다.
   - dto에 transactionTime에 추가했습니다.
   - dto에 balance를 추가했습니다. (매번 금액이 더 해지고 깎인 후 잔액을 추가했습니다)
   - 위와 같은 설계는 토스의 입출금내역을 참고했습니다.
- 이에 맞는 테스트코드를 작성했습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

잘 작동되는 것을 볼 수 있습니다.
<img width="960" alt="스크린샷 2022-08-02 오후 4 58 20" src="https://user-images.githubusercontent.com/87322089/182355684-8aa56373-a5ae-4e5f-b394-65b1e11a638d.png">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 제보 구매자 리스트를 구현하겠습니다.
- 대대적인 API 시트 정리에 들어가겠습니다. 