### PR TITLE
feat: implement logout with redis

### DIFF
--- a/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
+++ b/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
@@ -50,5 +50,10 @@ public class JwtAuthenticationAPI {
     }
 
 
-
+    //AcessToken을 받아 무효화 처리를 한다.
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/oauth2/sign-out")
+    public ResponseEntity logout(@RequestHeader(value = "Authorization") String accessToken) throws IOException{
+        return jwtAuthenticationService.logout(accessToken);
+    }
 }

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
@@ -76,7 +76,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService);
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtTokenProvider, principalDetailsService, redisService);
         return jwtAuthenticationFilter;
     }
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtEntryPoint.java
@@ -20,8 +20,10 @@ public class JwtEntryPoint implements AuthenticationEntryPoint {
 
 
         String exceptionInfo = (String) request.getAttribute("exception");
+
         //JwtAuthenticationFilter에서 전달받은 예외 내용
         if (exceptionInfo != null) {
+            log.info(exceptionInfo.toString());
             setException(response, exceptionInfo);
         }
         //PreAuthorize 어노테이션에 의한 예외

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -1,6 +1,7 @@
 package com.dope.breaking.service;
 
 import com.dope.breaking.exception.auth.ExpiredRefreshTokenException;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.auth.InvalidRefreshTokenException;
 import com.dope.breaking.security.jwt.JwtTokenProvider;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 
@@ -32,17 +34,19 @@ public class JwtAuthenticationService {
             try {
                 String username = jwtTokenProvider.getUsername(accessToken);
             } catch (ExpiredJwtException e) {
-               throw new ExpiredRefreshTokenException(); //만료 에러.
+                throw new ExpiredRefreshTokenException(); //만료 에러.
             } catch (SecurityException | IllegalArgumentException | JwtException e) {
-               throw new InvalidRefreshTokenException(); //유효하지 않은 예외.
+                throw new InvalidRefreshTokenException(); //유효하지 않은 예외.
             }
         } else if (getAccessToken != null && jwtTokenProvider.validateToken(getRefreshToken) == true) {
             String username = jwtTokenProvider.getUsername(getRefreshToken);
-            log.info(username);
             String redisRefreshToken = redisService.getData(username);
-            log.info(redisRefreshToken);
             if (!getRefreshToken.equals(redisRefreshToken)) { //Redis에 저장된 Refresh토큰이 존재하지 않을 때.
                 throw new InvalidRefreshTokenException();
+            }
+            if(jwtTokenProvider.validateToken(getAccessToken) == true) { //만일 유효한 엑세스토큰이라면 블랙리스트로 지정.
+                Long expiration = jwtTokenProvider.getExpireTime(getAccessToken);
+                redisService.setBlackListToken(getAccessToken, "BLACKLIST_ACCESSTOKEN_" + username, expiration); //엑세스 토큰 블랙리스트 저장
             }
 
             HttpHeaders httpHeaders = new HttpHeaders();
@@ -54,5 +58,17 @@ public class JwtAuthenticationService {
             return ResponseEntity.status(HttpStatus.OK).headers(httpHeaders).build();
         }
         return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+
+    public ResponseEntity<?> logout(String accessToken) throws IOException {
+        String getAccessToken = jwtTokenProvider.extractAccessToken(accessToken).orElse(null);
+
+        String username = jwtTokenProvider.getUsername(getAccessToken);
+        redisService.deleteValues(username); //레디스에 저장된 refreshToken 삭제
+
+        Long expiration = jwtTokenProvider.getExpireTime(getAccessToken);
+        redisService.setBlackListToken(getAccessToken, "BLACKLIST_ACCESSTOKEN_" + username, expiration); //엑세스 토큰 블랙리스트 저장
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -57,7 +57,7 @@ public class JwtAuthenticationService {
 
             return ResponseEntity.status(HttpStatus.OK).headers(httpHeaders).build();
         }
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        throw new InvalidRefreshTokenException();
     }
 
 

--- a/src/main/java/com/dope/breaking/service/RedisService.java
+++ b/src/main/java/com/dope/breaking/service/RedisService.java
@@ -15,6 +15,8 @@ import java.time.Duration;
 public class RedisService {
     private final RedisTemplate<String, Object> redisTemplate;
 
+    private final RedisTemplate<String, Object> redisBlackListTemplate; //블랙리스트를 위한 template
+
     public String getData(String key){
         return (String) redisTemplate.opsForValue().get(key); //key값을 바탕으로 value를 가져온다.
     }
@@ -32,9 +34,30 @@ public class RedisService {
         redisTemplate.opsForValue().set(key, value, expireDuration);
     }
 
+    public boolean hasKey(String key) {
+        return redisBlackListTemplate.hasKey(key);
+    }
 
     public void deleteValues(String key){ //데이터 삭제
         redisTemplate.delete(key);
+    }
+
+
+    public void setBlackListToken(String key, String value, Long time ){
+        Duration expireDuration = Duration.ofSeconds(time);
+        redisBlackListTemplate.opsForValue().set(key, value, expireDuration);
+    }
+
+    public Object getBlackListToken(String key) {
+        return redisBlackListTemplate.opsForValue().get(key);
+    }
+
+    public boolean hasKeyBlackListToken(String key) {
+        return redisBlackListTemplate.hasKey(key);
+    }
+
+    public void deleteBlackListToken(String key) {
+        redisBlackListTemplate.delete(key);
     }
 
 

--- a/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
@@ -68,10 +68,10 @@ class JwtAuthenticationFilterTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private static String USERNAME = "2318483287k";
+    private static String USERNAME = "";
     private static String PASSWORD = "123456789";
 
-    private static String accesstoken = "QSxDpx-bcxchYgE9tWNbsyx-98tsfMv16oB1MF1vCj11XAAAAYJmjVor";
+    private static String accesstoken = "";
 
     static String accessjwt;
     static String refreshjwt;

--- a/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dope/breaking/security/jwt/JwtAuthenticationFilterTest.java
@@ -68,10 +68,10 @@ class JwtAuthenticationFilterTest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    private static String USERNAME = "";
+    private static String USERNAME = "2318483287k";
     private static String PASSWORD = "123456789";
 
-    private static String accesstoken = "";
+    private static String accesstoken = "QSxDpx-bcxchYgE9tWNbsyx-98tsfMv16oB1MF1vCj11XAAAAYJmjVor";
 
     static String accessjwt;
     static String refreshjwt;
@@ -116,7 +116,7 @@ class JwtAuthenticationFilterTest {
     void noAccessAndRefreshToken() throws Exception {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/hello"))//login이 아닌 다른 임의의 주소
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError()); //아무것도 없다면 4xx 반환
+                .andExpect(MockMvcResultMatchers.status().isForbidden()); //아무것도 없다면 403
     }
 
     @DisplayName("유효한 엑세스 토큰만으로 인증된 유저만 접근 가능한 주소로 접근 시 정상적으로 요청이 완료된다.")
@@ -188,7 +188,44 @@ class JwtAuthenticationFilterTest {
         this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization", "Bearer " + accessjwt + "123456"))
                 .andDo(MockMvcResultHandlers.print())
                 //Then
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError()); //엑세스 토큰이 유효하지 않다면 4xx 반환.
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()); //엑세스 토큰이 유효하지 않다면 4xx 반환.
+
+
+        redisService.deleteValues(USERNAME);
+    }
+
+
+    @DisplayName("유저 정보가 없는 상태에서 엑세스 토큰으로 접근하려 할 시, 예외가 반환된다.")
+    @Transactional
+    @Test
+    void validTokenWithNotSignUp() throws Exception{
+        //Given
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+
+        //When
+        userRepository.delete(userRepository.findByUsername(USERNAME).get());
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/hello").header("Authorization", "Bearer " + accessjwt + "123456"))
+                .andDo(MockMvcResultHandlers.print())
+                //Then
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()); //엑세스 토큰이 유효하지 않다면 4xx 반환.
 
 
         redisService.deleteValues(USERNAME);
@@ -286,10 +323,12 @@ class JwtAuthenticationFilterTest {
         redisService.deleteValues(USERNAME);
     }
 
+
+
     @DisplayName("유효하지 않은 엑세스토큰이지만 유효한 리플리쉬 토큰으로 인증된 유저만 접근가능한 주소로 접근 시 예외를 반환한다.") //유효기간 또는 잘못된 시그니처를 포함한 엑세스 토큰과 올바른 refresh 토큰이 같이 왔다면 재발행.
     @Transactional
     @Test
-    void invalidAccessButValidRefresh() throws Exception{
+    void invalidAccessButValidRefresh() throws Exception {
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
 
@@ -314,17 +353,16 @@ class JwtAuthenticationFilterTest {
         refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
         System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
 
-        result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
-                        .header("Authorization", "Bearer " + accessjwt+ "2134") //accessjwt
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt + "2134") //accessjwt
                         .header("Authorization-Refresh", "Bearer " + refreshjwt))//refershjwt
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError()).andReturn();
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
 
         redisService.deleteValues(USERNAME);
 
+
     }
-
-
 
     @DisplayName("유효한 엑세스 토큰이지만 유효하지 않은 리플리쉬 토큰으로 인증된 유저만 접근 가능한 주소로 접근 시 정상적으로 요청이 완료된다.")
     @Transactional
@@ -368,7 +406,7 @@ class JwtAuthenticationFilterTest {
     @DisplayName("유효하지 않은 엑세스 토큰과 리플리쉬 토큰으로 인증된 유저만 접근 가능한 주소로 접근 시, 예외가 반환된다.")
     @Transactional
     @Test
-    void invalidAccessAndRefresh() throws Exception{
+    void notAccessTokenButRefreshTokenToAccess() throws Exception{
 
         userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
 
@@ -396,19 +434,11 @@ class JwtAuthenticationFilterTest {
 
 
         result  = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
-                        .header("Authorization", "Bearer " + accessjwt+ "2134") //accessjwt
-                        .header("Authorization-Refresh", "Bearer " + refreshjwt + "1245"))//refershjwt
+                        .header("Authorization", "Bearer " + refreshjwt)) //refresh토큰으로 접근하려 할시
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError()).andReturn(); //모두 잘못된 토큰이기에 4xx
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn(); //모두 잘못된 토큰이기에 4xx
 
          response = result.getResponse();
-        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
-        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
-        String reaccessjwt = (String) response.getHeaderValue("Authorization");
-        String rerefreshjwt = (String) response.getHeaderValue("Authorization-refresh");
-        Assertions.assertThat(reaccessjwt).isNull();
-        Assertions.assertThat(rerefreshjwt).isNull();
-
 
         redisService.deleteValues(USERNAME);
     }
@@ -460,6 +490,50 @@ class JwtAuthenticationFilterTest {
 
     }
 
+
+    @DisplayName("블랙리스트에 저장된 엑세스토큰으로 접근하려 할 시, 예외가 반환된다.")
+    @Transactional
+    @Test
+    void blackListAccessTokenToAcess() throws Exception {
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+
+
+        //When
+        redisService.setDataWithExpiration(accessjwt, "BlackListToken", jwtTokenProvider.getExpireTime(accessjwt)); //블랙리스트로 지정
+
+        //Then
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/hello")
+                        .header("Authorization", "Bearer " + accessjwt)) //accessjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
+
+        redisService.deleteValues(USERNAME);
+        redisService.deleteValues(accessjwt);
+
+    }
+
     @DisplayName("유효한 엑세스 토큰이지만 유효하지 않은 리플리쉬 토큰으로 재발행을 요청하면, 예외를 반환한다.")
     @Transactional
     @Test
@@ -493,12 +567,56 @@ class JwtAuthenticationFilterTest {
                         .header("Authorization", "Bearer " + accessjwt) //accessjwt
                         .header("Authorization-Refresh", "Bearer " + refreshjwt + "dsafsaf"))//refershjwt
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().is4xxClientError()).andReturn();
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
 
 
         redisService.deleteValues(USERNAME);
 
     }
+
+    @DisplayName("Redis에 존재하지 않은 리플리쉬 토큰으로 재발행을 요청하면, 예외를 반환한다.")
+    @Transactional
+    @Test
+    void notExistRefreshTokenInRedis() throws Exception {
+
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+        //When
+        redisService.deleteValues(USERNAME);
+
+        //Then
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/reissue")
+                        .header("Authorization", "Bearer " + accessjwt) //accessjwt
+                        .header("Authorization-Refresh", "Bearer " + refreshjwt + "dsafsaf"))//refershjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
+
+    }
+
+
+
 
     @DisplayName("유효하지 않은 엑세스 토큰과 유효한 리플리시 토큰으로 재발행을 요청하면 정상적으로 재발행된다.")
     @Transactional
@@ -541,6 +659,185 @@ class JwtAuthenticationFilterTest {
 
         redisService.deleteValues(USERNAME);
     }
+
+
+    @DisplayName("엑세스토큰없이 로그아웃을 요청하려 할 때, 예외가 반환횐다.")
+    @Transactional
+    @Test
+    void logoutWithoutAccessToken() throws Exception {
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/oauth2/sign-out").header("Authorization", ""))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isForbidden()).andReturn(); //403반환
+
+    }
+
+
+    @DisplayName("유효하지 읺은 엑세스토큰으로 로그아웃을 요청하려 할 때, 예외가 반환횐다.")
+    @Transactional
+    @Test
+    void logoutWithInvalidAccessToken() throws Exception {
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+
+
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/oauth2/sign-out")
+                        .header("Authorization", "Bearer " + accessjwt+"123")) //accessjwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
+
+
+
+        redisService.deleteValues(USERNAME);
+    }
+
+    @DisplayName("리플리쉬토큰으로 로그아웃을 요청하려 할 때, 예외가 반환횐다.")
+    @Transactional
+    @Test
+    void logoutWithRefreshToken() throws Exception {
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+
+
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/oauth2/sign-out")
+                        .header("Authorization", "Bearer " + refreshjwt)) //refreshJwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
+
+
+
+        redisService.deleteValues(USERNAME);
+    }
+
+
+    @DisplayName("유효한 엑세스토큰으로 로그아웃을 요청하려 할 때, 정상적으로 처리된다.")
+    @Transactional
+    @Test
+    void logoutWithValidAccessToken() throws Exception {
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+
+
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/oauth2/sign-out")
+                        .header("Authorization", "Bearer " + accessjwt)) //refreshJwt
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+
+
+        redisService.deleteValues(USERNAME);
+        redisService.deleteBlackListToken(accessjwt);
+    }
+
+
+    @DisplayName("로그아웃된 엑세스토큰으로 다시 로그아웃을 시도하려 할 시, 예외가 반환된다.")
+    @Transactional
+    @Test
+    void logoutWithBlackListAccessToken() throws Exception {
+        //Given
+        userRepository.save(User.builder().username(USERNAME).password(passwordEncoder.encode(PASSWORD)).role(Role.USER).build());
+
+        Map<String, String> info = new LinkedHashMap<>();
+
+        info.put("accessToken", accesstoken);
+
+        String content = objectMapper.writeValueAsString(info);
+        System.out.println(content);
+        MvcResult result = this.mockMvc.perform(MockMvcRequestBuilders
+                        .post("/oauth2/sign-in/kakao")
+                        .content(content)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn();
+
+        MockHttpServletResponse response = result.getResponse();
+        System.out.println("accessToken : " + response.getHeaderValue("Authorization"));
+        accessjwt = (String) response.getHeaderValue("Authorization");
+        System.out.println("refreshToken : " + response.getHeaderValue("Authorization-refresh"));
+        refreshjwt = (String) response.getHeaderValue("Authorization-refresh");
+        System.out.println("user refreshtoken : " + redisService.getData(refreshjwt));
+
+        //When
+        redisService.setBlackListToken(accessjwt, "blacklistAccessToken", jwtTokenProvider.getExpireTime(accessjwt));
+
+
+        result = this.mockMvc.perform(MockMvcRequestBuilders.get("/oauth2/sign-out")
+                        .header("Authorization", "Bearer " + accessjwt)) //accessToken
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized()).andReturn();
+
+
+
+        redisService.deleteValues(USERNAME);
+        redisService.deleteBlackListToken(accessjwt);
+    }
+
+
+
+
 
 
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #46 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 로그아웃 기능을 구현하였습니다.
  인증된 사용자만 로그아웃을 할 수 있도록 구현하였습니다. AccessToken만 해더로 받으며, 엑세스 토큰이 유효하다면, Redis에 저장된 RefreshToken을 삭제하여 기존의 Refresh토큰을 무효화합니다. 또한, 로그아웃 요청을 보낸 엑세스토큰을 레디스의 블랙리스트에 남은 만료기간을 같이 저장하여 레디스 내에서 만료기간 이후로 자동 삭제하도록 구현하였습니다.

2. 블랙리스트에 저장된 엑세스토큰으로 로그아웃을 시도하면, 예외가 반환됩니다. 

3. 추가로 재발급을 할 때로 재발급 받기 전의 엑세스토큰 역시 블랙리스트로 저장하여 기존의 엑세스토큰을 사용하지 못하도록 구현하였습니다. 

4. 마지막으로 엑세스토큰의 유효함을 확인하는 필터단에서, 블랙리스트에 존재하는지 엑세스토큰을 검사하는 로직을 추가하였습니다.

5. 로그아웃 구현의 테스트코드를 구현하여 이상없음을 확인하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="865" alt="스크린샷 2022-08-04 오후 12 19 46" src="https://user-images.githubusercontent.com/62254434/182755921-c93ca2a5-df42-4fc4-8d28-21ad61d92db8.png">
<img width="860" alt="스크린샷 2022-08-04 오후 12 02 50" src="https://user-images.githubusercontent.com/62254434/182755934-2d354272-25a7-4031-a21b-ddc02b83fac1.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
리플리쉬 토큰과 로그아웃이 구현되었으므로 노션에 구체적으로 기술하며 재정립 하곘습니다.