### PR TITLE
refactor: refactor layer structure of searching feed

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -27,7 +28,8 @@ public class FeedAPI {
 
     @GetMapping("/feed")
     public ResponseEntity<List<FeedResultPostDto>> searchFeed(
-            @RequestParam(value="cursor") Long cursor,
+            Principal principal,
+            @RequestParam(value="cursor") Long cursorId,
             @RequestParam(value="size") Long size,
             @RequestParam(value="search", required = false) String searchKeyword,
             @RequestParam(value="sort", required = false) String sortStrategy,
@@ -39,7 +41,6 @@ public class FeedAPI {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .searchKeyword(searchKeyword)
-                .cursorId(cursor)
                 .size(size)
                 .sortStrategy(SortStrategy.findMatchedEnum(sortStrategy))
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
@@ -49,28 +50,38 @@ public class FeedAPI {
                 .forLastMin(forLastMin)
                 .build();
 
-        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto));
+        String username = null;
+        if(principal!=null) {
+            username = principal.getName();
+        }
+
+        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto, username, cursorId));
 
     }
 
     @GetMapping("/feed/user/{ownerId}/{userFeedPostOption}")
     public ResponseEntity<List<FeedResultPostDto>> searchUserFeed(
+            Principal principal,
             @PathVariable("ownerId") Long ownerId,
             @PathVariable("userFeedPostOption") String userFeedPostOption,
-            @RequestParam(value="cursor") Long cursor,
+            @RequestParam(value="cursor") Long cursorId,
             @RequestParam(value="size") Long size,
             @RequestParam(value="sold-option", required = false, defaultValue = "ALL") String soldOption
     ) {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
-                .cursorId(cursor)
                 .size(size)
                 .ownerId(ownerId)
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
                 .userPageFeedOption(UserPageFeedOption.findMatchedEnum(userFeedPostOption))
                 .build();
 
-        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto));
+        String username = null;
+        if(principal!=null) {
+            username = principal.getName();
+        }
+
+        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto, username, cursorId));
 
     }
 

--- a/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
@@ -17,8 +17,6 @@ public class SearchFeedConditionDto {
 
     private String searchKeyword;
 
-    private Long cursorId;
-
     private Long size;
 
     private SortStrategy sortStrategy;
@@ -34,10 +32,9 @@ public class SearchFeedConditionDto {
     private Integer forLastMin;
 
     @Builder
-    public SearchFeedConditionDto(Long ownerId, String searchKeyword, Long cursorId, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
+    public SearchFeedConditionDto(Long ownerId, String searchKeyword, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
         this.ownerId = ownerId;
         this.searchKeyword = searchKeyword;
-        this.cursorId = cursorId;
         this.size = size;
         this.sortStrategy = sortStrategy;
         this.soldOption = soldOption;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 
@@ -8,5 +9,5 @@ import java.util.List;
 
 public interface FeedRepositoryCustom {
 
-    List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost);
+    List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -1,6 +1,7 @@
 package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.QFeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
@@ -35,7 +36,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost) {
+    public List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me) {
 
         List<Tuple> paginatedResult = queryFactory
                 .select(post.id, postLike.post.id.count())

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -1,11 +1,14 @@
 package com.dope.breaking.service;
 
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.repository.FeedRepository;
 import com.dope.breaking.repository.PostRepository;
+import com.dope.breaking.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -19,11 +22,18 @@ public class SearchFeedService {
     private final FeedRepository feedRepository;
     private final PostRepository postRepository;
 
-    public List<FeedResultPostDto> searchFeed(SearchFeedConditionDto searchFeedConditionDto) {
+    private final UserRepository userRepository;
+
+    public List<FeedResultPostDto> searchFeed(SearchFeedConditionDto searchFeedConditionDto, String username, Long cursorId) {
+
+        User me = null;
+        if(username != null) {
+            me = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        }
 
         Post cursorPost = null;
-        if(searchFeedConditionDto.getCursorId() != null && searchFeedConditionDto.getCursorId() != 0) {
-            cursorPost = postRepository.findById(searchFeedConditionDto.getCursorId()).orElseThrow(NoSuchPostException::new);
+        if(cursorId != null && cursorId != 0) {
+            cursorPost = postRepository.findById(cursorId).orElseThrow(NoSuchPostException::new);
         }
 
         if(searchFeedConditionDto.getForLastMin() != null) {
@@ -31,7 +41,7 @@ public class SearchFeedService {
             searchFeedConditionDto.setDateTo(LocalDateTime.now());
         }
 
-        return feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost);
+        return feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
     }
 
 }

--- a/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
@@ -266,6 +266,7 @@ public class FeedServiceRepositoryTest {
         assertEquals(page, content2.size());
         assertEquals(page, content6.size());
         assertEquals(0, content7.size(), () -> "남은 포스트 10개는 숨김처리되어 조회되지 않는다.");
+        
     }
 
     @DisplayName("유저페이지에서는 해당 유저가 작성한 게시글만 조회된다.")

--- a/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.service;
+package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Post;
@@ -7,32 +7,32 @@ import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
-import com.dope.breaking.repository.FeedRepository;
-import com.dope.breaking.repository.PostLikeRepository;
-import com.dope.breaking.repository.PostRepository;
-import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.service.SoldOption;
+import com.dope.breaking.service.SortStrategy;
+import com.dope.breaking.service.UserPageFeedOption;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
-
+import javax.transaction.Transactional;
 import java.util.List;
 
 import static com.dope.breaking.domain.user.Role.PRESS;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@Transactional
+
 @SpringBootTest
-class FeedSearchServiceTest {
+@Transactional
+public class FeedServiceRepositoryTest {
 
     @Autowired PostRepository postRepository;
+
     @Autowired FeedRepository feedRepository;
     @Autowired PostLikeRepository postLikeRepository;
-    @Autowired SearchFeedService searchFeedService;
-    @Autowired EntityManager em;
+    @Autowired
+    EntityManager em;
     @Autowired UserRepository userRepository;
 
     @DisplayName("포스트가 없으면, 에러가 나지 않고 빈 배열을 반환한다.")
@@ -40,12 +40,11 @@ class FeedSearchServiceTest {
     void whenThereAreNoPosts() {
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .cursorId(null)
                 .size(15L)
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = searchFeedService.searchFeed(searchFeedConditionDto);
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, null);
 
         assertEquals(0, result.size());
     }
@@ -89,20 +88,19 @@ class FeedSearchServiceTest {
         //첫번째 게시글 조회
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .cursorId(null)
                 .size(1L)
                 .soldOption(SoldOption.ALL)
                 .sortStrategy(SortStrategy.LIKE)
                 .build();
-        List<FeedResultPostDto> content1 = searchFeedService.searchFeed(searchFeedConditionDto);
+        List<FeedResultPostDto> content1 = feedRepository.searchFeedBy(searchFeedConditionDto, null, null);
 
         //두번째 게시글 조회
-        searchFeedConditionDto.setCursorId(content1.get(0).getPostId());
-        List<FeedResultPostDto> content2 = searchFeedService.searchFeed(searchFeedConditionDto);
+        Post cursorPost = postRepository.findById(content1.get(0).getPostId()).get();
+        List<FeedResultPostDto> content2 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         //세번째 게시글 조회
-        searchFeedConditionDto.setCursorId(content2.get(0).getPostId());
-        List<FeedResultPostDto> content3 = searchFeedService.searchFeed(searchFeedConditionDto);
+        cursorPost = postRepository.findById(content2.get(0).getPostId()).get();
+        List<FeedResultPostDto> content3 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         //then 3 1 2 순서
         assertEquals(thirdPost.getId(), content1.get(0).getPostId(), ()->"좋아요가 1인 게시글이 조회된다.");
@@ -155,24 +153,23 @@ class FeedSearchServiceTest {
         //첫번째 게시글 조회
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .cursorId(null)
                 .size(1L)
                 .soldOption(SoldOption.ALL)
                 .sortStrategy(SortStrategy.VIEW)
                 .build();
-        List<FeedResultPostDto> content1 = searchFeedService.searchFeed(searchFeedConditionDto);
+        List<FeedResultPostDto> content1 = feedRepository.searchFeedBy(searchFeedConditionDto, null, null);
 
         //두번째 게시글 조회
-        searchFeedConditionDto.setCursorId(content1.get(0).getPostId());
-        List<FeedResultPostDto> content2 = searchFeedService.searchFeed(searchFeedConditionDto);
+        Post cursorPost = postRepository.findById(content1.get(0).getPostId()).get();
+        List<FeedResultPostDto> content2 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         //세번째 게시글 조회
-        searchFeedConditionDto.setCursorId(content2.get(0).getPostId());
-        List<FeedResultPostDto> content3 = searchFeedService.searchFeed(searchFeedConditionDto);
+        cursorPost = postRepository.findById(content2.get(0).getPostId()).get();
+        List<FeedResultPostDto> content3 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         //네번째 게시글 조회
-        searchFeedConditionDto.setCursorId(content3.get(0).getPostId());
-        List<FeedResultPostDto> content4 = searchFeedService.searchFeed(searchFeedConditionDto);
+        cursorPost = postRepository.findById(content3.get(0).getPostId()).get();
+        List<FeedResultPostDto> content4 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         //then 3 1 2 순서
         assertEquals(secondPost.getId(), content1.get(0).getPostId(), ()->content1.get(0).getViewCount() + " :조회수가 3인 게시글이 조회된다.");
@@ -246,25 +243,24 @@ class FeedSearchServiceTest {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .cursorId(null)
                 .size(page)
                 .soldOption(SoldOption.ALL)
                 .sortStrategy(SortStrategy.CHRONOLOGICAL)
                 .build();
 
-        List<FeedResultPostDto> content1 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content1.get(content1.size() - 1).getPostId());
-        List<FeedResultPostDto> content2 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content2.get(content2.size() - 1).getPostId());
-        List<FeedResultPostDto> content3 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content3.get(content3.size() - 1).getPostId());
-        List<FeedResultPostDto> content4 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content4.get(content4.size() - 1).getPostId());
-        List<FeedResultPostDto> content5 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content5.get(content5.size() - 1).getPostId());
-        List<FeedResultPostDto> content6 = searchFeedService.searchFeed(searchFeedConditionDto);
-        searchFeedConditionDto.setCursorId(content6.get(content6.size() - 1).getPostId());
-        List<FeedResultPostDto> content7 = searchFeedService.searchFeed(searchFeedConditionDto);
+        List<FeedResultPostDto> content1 = feedRepository.searchFeedBy(searchFeedConditionDto, null, null);
+        Post cursorPost = postRepository.findById(content1.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content2 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
+        cursorPost = postRepository.findById(content2.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content3 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
+        cursorPost = postRepository.findById(content3.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content4 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
+        cursorPost = postRepository.findById(content4.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content5 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
+        cursorPost = postRepository.findById(content5.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content6 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
+        cursorPost = postRepository.findById(content6.get(content1.size() - 1).getPostId()).get();
+        List<FeedResultPostDto> content7 = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, null);
 
         assertEquals(page, content1.size());
         assertEquals(page, content2.size());
@@ -305,15 +301,13 @@ class FeedSearchServiceTest {
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
                 .ownerId(owner.getId())
-                .cursorId(null)
                 .size(10L)
                 .userPageFeedOption(UserPageFeedOption.WRITE)
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> content = searchFeedService.searchFeed(searchFeedConditionDto);
+        List<FeedResultPostDto> content = feedRepository.searchFeedBy(searchFeedConditionDto, null,null);
 
         assertEquals(7, content.size());
     }
-
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #174 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 피드 조회 api의 전체적인 layer의 역할을 변경했습니다.
- service 테스트 코드를 repository로 옮겼습니다.
- 
## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
흑흑..
좋은 구조에 대해서 고민하다보니, feed 리팩토링만 몇 번 째인지..

===========
이번에 기존에 service test에 있던 것을 repository test로 싹! 옮겼습니다.
추후에 테스트를 좀 공부해보고, service 로직을 테스트하는 코드를 작성하고 공유해보겠습니다.

이전에 여러분들께 한 번씩 말씀드렸는데,
아무래도 기존의 테스트 방식을 좀 엎어버릴 필요성이 있는 것 같습니다.

실제 DB에 저장되는 것은 repository 계층에서 끝내고,
service 계층은 mocking을 통해서, business logic 이 잘 실행되는지에 대해서만 테스트 하면 좋을 것 같습니다.

추후에 제가 어떤 방식인지 공부해서 공유할게요!
