### PR TITLE
fix: unexpected exception there are no comments

### DIFF
--- a/src/main/java/com/dope/breaking/service/CommentService.java
+++ b/src/main/java/com/dope/breaking/service/CommentService.java
@@ -107,10 +107,13 @@ public class CommentService {
                 if(!postRepository.existsById(searchCommentConditionDto.getTargetId())) {
                     throw new NoSuchPostException();
                 }
+                break;
+
             case COMMENT:
                 if(!commentRepository.existsById(searchCommentConditionDto.getTargetId())) {
                     throw new NoSuchCommentException();
                 }
+                break;
         }
 
         return commentRepository.searchCommentList(me, searchCommentConditionDto);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #179 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
switch case 에 break 를 넣지 않는 사고를 쳐서, 상단에 있는 조건이 실행되면 하단에 있는 조건은 모두 실행되어버리는 버그 발생.
하필 exception이 터지는 곳에 이런 실수를 해서, 디버깅 하는데 굉장히 오래 걸렸습니다. 