### PR TITLE
feat: add isLiked and isBookmarked fields for feed

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -74,6 +74,7 @@ public class FeedAPI {
                 .ownerId(ownerId)
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
                 .userPageFeedOption(UserPageFeedOption.findMatchedEnum(userFeedPostOption))
+                .sortStrategy(SortStrategy.CHRONOLOGICAL)
                 .build();
 
         String username = null;

--- a/src/main/java/com/dope/breaking/repository/BookmarkRepository.java
+++ b/src/main/java/com/dope/breaking/repository/BookmarkRepository.java
@@ -11,4 +11,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     int countByPost(Post post);
 
     void deleteByUserAndPost(User user, Post post);
+
+    Boolean existsByUserAndPostId(User me, Long postId);
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -30,9 +30,14 @@ import static com.dope.breaking.domain.user.QUser.user;
 public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final BookmarkRepository bookmarkRepository;
 
-    public FeedRepositoryCustomImpl(EntityManager em) {
+    private final PostLikeRepository postLikeRepository;
+
+    public FeedRepositoryCustomImpl(EntityManager em, BookmarkRepository bookmarkRepository, PostLikeRepository postLikeRepository) {
         this.queryFactory = new JPAQueryFactory(em);
+        this.bookmarkRepository = bookmarkRepository;
+        this.postLikeRepository = postLikeRepository;
     }
 
     @Override
@@ -63,7 +68,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                         post.title,
                         post.location.region,
                         post.thumbnailImgURL,
-                        Expressions.asNumber(0),
+                        post.postLikeList.size(),
                         post.postType,
                         post.isSold,
                         post.viewCount,
@@ -80,6 +85,11 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 .where(post.id.in(contentIdList))
                 .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()), boardSort(SortStrategy.CHRONOLOGICAL))
                 .fetch();
+
+        for(FeedResultPostDto dto : content) {
+            dto.setIsBookmarked(bookmarkRepository.existsByUserAndPostId(me, dto.getPostId()));
+            dto.setIsLiked(postLikeRepository.existsByUserAndPostId(me, dto.getPostId()));
+        }
 
         return content;
     }

--- a/src/main/java/com/dope/breaking/repository/PostLikeRepository.java
+++ b/src/main/java/com/dope/breaking/repository/PostLikeRepository.java
@@ -19,4 +19,6 @@ public interface PostLikeRepository extends JpaRepository<PostLike,Long> {
 
     List<PostLike> findAllByPost(Post post);
 
+    Boolean existsByUserAndPostId(User user, Long postId);
+
 }

--- a/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.Bookmark;
+import com.dope.breaking.domain.user.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Transactional
+@SpringBootTest
+public class BookmarkRepositoryTest {
+
+    @Autowired private BookmarkRepository bookmarkRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+
+    @DisplayName("유저가 북마크를 한 게시물이면, true가 반한된다.")
+    @Test
+    void bookmarkExistByUser() {
+        User user = new User();
+        userRepository.save(user);
+        Post post = new Post();
+        postRepository.save(post);
+        Bookmark bookmark = new Bookmark(user, post);
+        bookmarkRepository.save(bookmark);
+
+        assertTrue(bookmarkRepository.existsByUserAndPostId(user, post.getId()));
+    }
+}

--- a/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @SpringBootTest
 public class BookmarkRepositoryTest {
 
-    @Autowired private BookmarkRepository bookmarkRepository;
+    @Autowired BookmarkRepository bookmarkRepository;
     @Autowired UserRepository userRepository;
     @Autowired PostRepository postRepository;
 

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -1,0 +1,82 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.user.Bookmark;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.post.FeedResultPostDto;
+import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.service.SearchFeedService;
+import com.dope.breaking.service.SoldOption;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transactional;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest
+@Transactional
+public class FeedRepositoryTest {
+
+    @Autowired FeedRepository feedRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired PostLikeRepository postLikeRepository;
+    @Autowired BookmarkRepository bookmarkRepository;
+
+    @Autowired EntityManager em;
+
+    @DisplayName("유저가 like한 게시글은, isLiked가 true로 반환된다.")
+    @Test
+    void feedIsLike() {
+
+        User user = new User();
+        userRepository.save(user);
+        Post post = new Post();
+        postRepository.save(post);
+        PostLike postLike = new PostLike(user, post);
+        postLikeRepository.save(postLike);
+
+        em.flush();
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(1L)
+                .soldOption(SoldOption.ALL)
+                .build();
+
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+
+        assertTrue(result.get(0).getIsLiked());
+    }
+
+    @DisplayName("유저가 bookmark한 게시글은, isBookmarked가 true로 반환된다.")
+    @Test
+    void feedIsBookmarked() {
+
+        User user = new User();
+        userRepository.save(user);
+        Post post = new Post();
+        postRepository.save(post);
+        Bookmark bookmark = new Bookmark(user, post);
+        bookmarkRepository.save(bookmark);
+
+        em.flush();
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(1L)
+                .soldOption(SoldOption.ALL)
+                .build();
+
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+
+        assertTrue(result.get(0).getIsBookmarked());
+    }
+
+}

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -17,6 +17,7 @@ import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
@@ -53,6 +54,7 @@ public class FeedRepositoryTest {
         List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
 
         assertTrue(result.get(0).getIsLiked());
+        assertEquals(1, result.get(0).getLikeCount());
     }
 
     @DisplayName("유저가 bookmark한 게시글은, isBookmarked가 true로 반환된다.")

--- a/src/test/java/com/dope/breaking/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/PostLikeRepositoryTest.java
@@ -1,0 +1,37 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.user.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+public class PostLikeRepositoryTest {
+
+    @Autowired UserRepository userRepository;
+    @Autowired PostRepository postRepository;
+    @Autowired PostLikeRepository postLikeRepository;
+
+    @DisplayName("유저가 좋아요를 한 게시물이면, true가 반한된다.")
+    @Test
+    void postLikeExist() {
+
+        User user = new User();
+        userRepository.save(user);
+        Post post = new Post();
+        postRepository.save(post);
+        PostLike postLike = new PostLike(user, post);
+        postLikeRepository.save(postLike);
+
+        assertTrue(postLikeRepository.existsByUserAndPostId(user, post.getId()));
+    }
+}

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -1,0 +1,71 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.post.FeedResultPostDto;
+import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.repository.FeedRepository;
+import com.dope.breaking.repository.PostRepository;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedServiceTest {
+
+    @Mock
+    private FeedRepository feedRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private SearchFeedService feedService;
+
+    @Test
+    void searchUserPageTest() {
+
+        //given
+        User user = new User();
+        Post post1 = Post.builder()
+                .title("post1")
+                .build();
+        post1.setUser(user);
+        Post post2 = Post.builder()
+                .title("post2")
+                .build();
+        post2.setUser(user);
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder().build();
+
+        Mockito.lenient().when(userRepository.findByUsername(null)).thenReturn(Optional.of(user));
+        Mockito.lenient().when(postRepository.findById(0L)).thenReturn(null);
+        List<FeedResultPostDto> dummy = new ArrayList<>();
+        FeedResultPostDto content1 = new FeedResultPostDto();
+        content1.setTitle("post1");
+        dummy.add(content1);
+        FeedResultPostDto content2 = new FeedResultPostDto();
+        content2.setTitle("post2");
+        dummy.add(content2);
+        given(feedRepository.searchFeedBy(searchFeedConditionDto, null, null)).willReturn(dummy);
+
+        //when
+        List<FeedResultPostDto> result = feedService.searchFeed(searchFeedConditionDto, null, null);
+
+        //then
+        Assertions.assertEquals(2, result.size());
+    }
+}

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -8,6 +8,7 @@ import com.dope.breaking.repository.FeedRepository;
 import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -35,6 +36,7 @@ public class FeedServiceTest {
     @InjectMocks
     private SearchFeedService feedService;
 
+    @DisplayName("유저 피드 조회가 정상적으로 작동한다.")
     @Test
     void searchUserPageTest() {
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #168 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에 구현이 안되어서 작성하지 않았던 isLiked 와 isBookmarked 를 활성화 했습니다.

## 기타
이번에 서비스 layer 를 mockito로 작성을 해봤는데,
꽤나 어렵습니다 ㅠㅠ

특히 List<DTO> 같은 형식의 경우에, dummy 를 만들어 줘야 하는데,
이게 쉽지가 않네요.
repository layer에서의 결과가 복잡하게 나오면 쓰기 힘든듯 ㅠㅠ

단순 생성, 수정, 조회 는 쉬울듯!