### PR TITLE
refactor: extend varchar limit for content in database

### DIFF
--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -1,7 +1,5 @@
 package com.dope.breaking.domain.post;
 
-
-
 import com.dope.breaking.domain.baseTimeEntity.BaseTimeEntity;
 import com.dope.breaking.domain.comment.Comment;
 import com.dope.breaking.domain.financial.Purchase;
@@ -59,6 +57,7 @@ public class Post extends BaseTimeEntity {
 
     private String title;
 
+    @Column(length = 2500)
     private String content;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #190 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
문자열 제한 길이를 디폴트인 255에서 2500으로 늘렸습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
