### PR TITLE
feat: activate user page options

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -71,7 +71,6 @@ public class FeedAPI {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .size(size)
-                .ownerId(ownerId)
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
                 .userPageFeedOption(UserPageFeedOption.findMatchedEnum(userFeedPostOption))
                 .sortStrategy(SortStrategy.CHRONOLOGICAL)
@@ -82,7 +81,7 @@ public class FeedAPI {
             username = principal.getName();
         }
 
-        return ResponseEntity.ok().body(searchFeedService.searchUserFeed(searchFeedConditionDto, username, cursorId));
+        return ResponseEntity.ok().body(searchFeedService.searchUserFeed(searchFeedConditionDto, ownerId, username, cursorId));
 
     }
 

--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -55,7 +55,7 @@ public class FeedAPI {
             username = principal.getName();
         }
 
-        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto, username, cursorId));
+        return ResponseEntity.ok().body(searchFeedService.searchMainFeed(searchFeedConditionDto, username, cursorId));
 
     }
 
@@ -82,7 +82,7 @@ public class FeedAPI {
             username = principal.getName();
         }
 
-        return ResponseEntity.ok().body(searchFeedService.searchFeed(searchFeedConditionDto, username, cursorId));
+        return ResponseEntity.ok().body(searchFeedService.searchUserFeed(searchFeedConditionDto, username, cursorId));
 
     }
 

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -35,6 +35,9 @@ public class Post extends BaseTimeEntity {
     @JoinColumn (name="USER_ID")
     private User user;
 
+    @OneToMany(mappedBy = "post")
+    private List<Purchase> purchaseList = new ArrayList<Purchase>();
+
     @OneToMany(mappedBy="post")
     private List<Comment> commentList = new ArrayList<Comment>();
 

--- a/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
@@ -13,8 +13,6 @@ import java.time.LocalDateTime;
 @Setter
 public class SearchFeedConditionDto {
 
-    private Long ownerId;
-
     private String searchKeyword;
 
     private Long size;
@@ -32,8 +30,7 @@ public class SearchFeedConditionDto {
     private Integer forLastMin;
 
     @Builder
-    public SearchFeedConditionDto(Long ownerId, String searchKeyword, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
-        this.ownerId = ownerId;
+    public SearchFeedConditionDto(String searchKeyword, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
         this.searchKeyword = searchKeyword;
         this.size = size;
         this.sortStrategy = sortStrategy;

--- a/src/main/java/com/dope/breaking/exception/user/LoginRequireException.java
+++ b/src/main/java/com/dope/breaking/exception/user/LoginRequireException.java
@@ -1,0 +1,12 @@
+package com.dope.breaking.exception.user;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class LoginRequireException extends BreakingException {
+
+    public LoginRequireException(){
+        super(ErrorCode.REQUIRE_LOGIN, HttpStatus.NOT_ACCEPTABLE);
+    }
+}

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -10,4 +10,7 @@ import java.util.List;
 public interface FeedRepositoryCustom {
 
     List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
+
+    List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
+
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -11,6 +11,6 @@ public interface FeedRepositoryCustom {
 
     List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
 
-    List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
+    List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
 
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -96,7 +96,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
     }
 
     @Override
-    public List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me) {
+    public List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost) {
 
         List<Tuple> paginatedResult = queryFactory
                 .select(post.id, postLike.post.id.count())
@@ -106,7 +106,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 .leftJoin(post.purchaseList, purchase)
                 .where(
                         post.isHidden.eq(false),
-                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), searchFeedConditionDto.getOwnerId(), me),
+                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), owner, me),
                         cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
                         sameLevelCursorFilter(cursorPost, searchFeedConditionDto.getSortStrategy())
                 )
@@ -149,7 +149,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
         return content;
     }
 
-    private Predicate userPageFeedOption(UserPageFeedOption userPageFeedOption, Long ownerId, User me) {
+    private Predicate userPageFeedOption(UserPageFeedOption userPageFeedOption, User owner, User me) {
 
         if(userPageFeedOption == null) {
             return null;
@@ -162,7 +162,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 return bookmark.user.eq(me);
             case WRITE:
             default:
-                return post.user.id.eq(ownerId);
+                return post.user.eq(owner);
         }
     }
 

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -21,7 +21,6 @@ public class SearchFeedService {
 
     private final FeedRepository feedRepository;
     private final PostRepository postRepository;
-
     private final UserRepository userRepository;
 
     public List<FeedResultPostDto> searchFeed(SearchFeedConditionDto searchFeedConditionDto, String username, Long cursorId) {
@@ -41,7 +40,12 @@ public class SearchFeedService {
             searchFeedConditionDto.setDateTo(LocalDateTime.now());
         }
 
-        return feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
+        if(searchFeedConditionDto.getUserPageFeedOption() != null) {
+            return feedRepository.searchUserPageBy(searchFeedConditionDto, cursorPost, me);
+        } else {
+            return feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
+        }
+
     }
 
 }

--- a/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
@@ -304,13 +304,12 @@ public class FeedServiceRepositoryTest {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .ownerId(owner.getId())
                 .size(10L)
                 .userPageFeedOption(UserPageFeedOption.WRITE)
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> content = feedRepository.searchUserPageBy(searchFeedConditionDto, null,null);
+        List<FeedResultPostDto> content = feedRepository.searchUserPageBy(searchFeedConditionDto, owner,null, null);
 
         assertEquals(7, content.size());
     }
@@ -345,13 +344,12 @@ public class FeedServiceRepositoryTest {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .ownerId(owner.getId())
                 .size(3L)
                 .userPageFeedOption(UserPageFeedOption.BOOKMARK)
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, null, owner);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, null, null);
 
         assertEquals(3, result.size());
     }
@@ -386,13 +384,12 @@ public class FeedServiceRepositoryTest {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
-                .ownerId(owner.getId())
                 .size(3L)
                 .userPageFeedOption(UserPageFeedOption.BUY)
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, null, owner);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, null, null);
 
         assertEquals(3, result.size());
     }

--- a/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
@@ -349,7 +349,7 @@ public class FeedServiceRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, null, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, owner, null);
 
         assertEquals(3, result.size());
     }
@@ -389,7 +389,7 @@ public class FeedServiceRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, null, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, owner, null);
 
         assertEquals(3, result.size());
     }

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -4,6 +4,7 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.exception.user.LoginRequireException;
 import com.dope.breaking.exception.user.NoPermissionException;
 import com.dope.breaking.repository.FeedRepository;
 import com.dope.breaking.repository.PostRepository;
@@ -103,6 +104,88 @@ public class FeedServiceTest {
 
         //when, then
         Assertions.assertThrows(NoPermissionException.class, ()->feedService.searchUserFeed(searchFeedConditionDto, 1L, "guestUsername", null));
+
+    }
+
+    @DisplayName("다른 유저의 구매 리스트를 조회할 때, 예외가 발생한다.")
+    @Test
+    void failureWhenOtherUserSearchOtherUserPurchaseList() {
+
+        //given
+
+        User guest = User.builder()
+                .username("guestUsername")
+                .build();
+
+        User owner = User.builder()
+                .username("ownerUsername")
+                .build();
+
+        Post post = Post.builder()
+                .title("post1")
+                .build();
+        post.setUser(owner);
+
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.BUY)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+        when(userRepository.findByUsername("guestUsername")).thenReturn(Optional.of(guest));
+
+        //when, then
+        Assertions.assertThrows(NoPermissionException.class, ()->feedService.searchUserFeed(searchFeedConditionDto, 1L, "guestUsername", null));
+
+    }
+
+    @DisplayName("로그인 하지 않은 유저가 북마크 리스트를 조회할 때, 예외가 발생한다.")
+    @Test
+    void failureWhenGuestSearchOtherUserBookmarkList() {
+
+        User owner = User.builder()
+                .username("ownerUsername")
+                .build();
+
+        Post post = Post.builder()
+                .title("post1")
+                .build();
+        post.setUser(owner);
+
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.BOOKMARK)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+
+        //when, then
+        Assertions.assertThrows(LoginRequireException.class, ()->feedService.searchUserFeed(searchFeedConditionDto, 1L, null, null));
+
+    }
+
+    @DisplayName("로그인 하지 않은 유저가 구매 리스트를 조회할 때, 예외가 발생한다.")
+    @Test
+    void failureWhenGuestSearchOtherUserPurchaseList() {
+
+        User owner = User.builder()
+                .username("ownerUsername")
+                .build();
+
+        Post post = Post.builder()
+                .title("post1")
+                .build();
+        post.setUser(owner);
+
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.BUY)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+
+        //when, then
+        Assertions.assertThrows(LoginRequireException.class, ()->feedService.searchUserFeed(searchFeedConditionDto, 1L, null, null));
 
     }
 }

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -67,7 +67,7 @@ public class FeedServiceTest {
         given(feedRepository.searchUserPageBy(searchFeedConditionDto, null, null)).willReturn(dummy);
 
         //when
-        List<FeedResultPostDto> result = feedService.searchFeed(searchFeedConditionDto, null, null);
+        List<FeedResultPostDto> result = feedService.searchUserFeed(searchFeedConditionDto, null, null);
 
         //then
         Assertions.assertEquals(2, result.size());

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -51,7 +51,9 @@ public class FeedServiceTest {
                 .build();
         post2.setUser(user);
 
-        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder().build();
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.WRITE)
+                .build();
 
         Mockito.lenient().when(userRepository.findByUsername(null)).thenReturn(Optional.of(user));
         Mockito.lenient().when(postRepository.findById(0L)).thenReturn(null);
@@ -62,7 +64,7 @@ public class FeedServiceTest {
         FeedResultPostDto content2 = new FeedResultPostDto();
         content2.setTitle("post2");
         dummy.add(content2);
-        given(feedRepository.searchFeedBy(searchFeedConditionDto, null, null)).willReturn(dummy);
+        given(feedRepository.searchUserPageBy(searchFeedConditionDto, null, null)).willReturn(dummy);
 
         //when
         List<FeedResultPostDto> result = feedService.searchFeed(searchFeedConditionDto, null, null);

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -4,6 +4,7 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.exception.user.NoPermissionException;
 import com.dope.breaking.repository.FeedRepository;
 import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class FeedServiceTest {
@@ -41,22 +43,21 @@ public class FeedServiceTest {
     void searchUserPageTest() {
 
         //given
-        User user = new User();
+        User owner = new User();
         Post post1 = Post.builder()
                 .title("post1")
                 .build();
-        post1.setUser(user);
+        post1.setUser(owner);
         Post post2 = Post.builder()
                 .title("post2")
                 .build();
-        post2.setUser(user);
+        post2.setUser(owner);
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .userPageFeedOption(UserPageFeedOption.WRITE)
                 .build();
 
-        Mockito.lenient().when(userRepository.findByUsername(null)).thenReturn(Optional.of(user));
-        Mockito.lenient().when(postRepository.findById(0L)).thenReturn(null);
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
         List<FeedResultPostDto> dummy = new ArrayList<>();
         FeedResultPostDto content1 = new FeedResultPostDto();
         content1.setTitle("post1");
@@ -64,12 +65,44 @@ public class FeedServiceTest {
         FeedResultPostDto content2 = new FeedResultPostDto();
         content2.setTitle("post2");
         dummy.add(content2);
-        given(feedRepository.searchUserPageBy(searchFeedConditionDto, null, null)).willReturn(dummy);
+        given(feedRepository.searchUserPageBy(searchFeedConditionDto, owner, null, null)).willReturn(dummy);
 
         //when
-        List<FeedResultPostDto> result = feedService.searchUserFeed(searchFeedConditionDto, null, null);
+        List<FeedResultPostDto> result = feedService.searchUserFeed(searchFeedConditionDto, 1L, null, null);
 
         //then
         Assertions.assertEquals(2, result.size());
+    }
+
+    @DisplayName("다른 유저의 북마크 리스트를 조회할 때, 예외가 발생한다.")
+    @Test
+    void failureWhenOtherUserSearchOtherUserBookmarkList() {
+
+        //given
+
+        User guest = User.builder()
+                .username("guestUsername")
+                .build();
+
+        User owner = User.builder()
+                .username("ownerUsername")
+                .build();
+
+        Post post = Post.builder()
+                .title("post1")
+                .build();
+        post.setUser(owner);
+
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.BOOKMARK)
+                .build();
+
+        when(userRepository.findById(1L)).thenReturn(Optional.of(owner));
+        when(userRepository.findByUsername("guestUsername")).thenReturn(Optional.of(guest));
+
+        //when, then
+        Assertions.assertThrows(NoPermissionException.class, ()->feedService.searchUserFeed(searchFeedConditionDto, 1L, "guestUsername", null));
+
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #169 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저 페이지 피드의 구매한제보/북마크한 제보의 필드를 활성화 했습니다.
- 구매한제보/북마크한 제보에는 본인만 접근할 수 있도록 처리하였습니다.
- mockito 를 활용한 service layer 테스트를 적용했습니다.
- 기존 메인 피드로부터 변경점이 많아져서, 로직의 복잡도를 고려해 분리하였습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
### 앞으로의 테스트는 이렇게 하면 좋을 것 같습니다.

**Repository Layer**
DB와 필연적으로 관련된 로직들은 repository layer에서 기존 방식과 동일하게 memory test db 를 활용하여 테스트 하시면 됩니다.

**Service Layer**
조금 더 정리가 되면, 최대한 mockito 를 이용해서 service layer를 테스트하려고 합니다.
repository layer를 신경쓰지 않고, 정확하게 비즈니스 로직과 예외처리들이 동작하는지에 대해서만 테스트 하면 됩니다.

이번 저의 테스트 코드를 보시면, 발생할 수 있는 모든 예외처리를 중심으로 작성한 것을 보실 수 있습니다.

**Controller Layer**
controller도 마찬가지로 적용을 하려고 몇 시간 삽질을 했으나, security의 filter 문제가 있어서 어려움을 겪고 있습니다.
이것도 해답을 찾으면 공유하겠습니다.
모의 요청은 여러분들이 기존에 작성했던 방식과 동일합니다.