### PR TITLE
feat: send error log to slack

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.11'
 	implementation group: 'org.jcodec', name: 'jcodec', version: '0.2.5'
 	implementation group: 'org.jcodec', name: 'jcodec-javase', version: '0.2.5'
+	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 
 }
 

--- a/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
+++ b/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
@@ -11,6 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 @Slf4j
 @ControllerAdvice
 public class CustomExceptionHandler {
@@ -18,7 +21,13 @@ public class CustomExceptionHandler {
     @ExceptionHandler(CustomInternalErrorException.class)
     protected ResponseEntity<ErrorResponseDto> handleCustomInternalErrorException(CustomInternalErrorException e) {
 
-        log.error(e.getMessage());
+        StringWriter sw = new StringWriter();
+        e.printStackTrace(new PrintWriter(sw));
+        String stacktraceAsString = sw.toString();
+
+        log.error(stacktraceAsString);
+        System.out.println("e.getMessage() = " + e.getMessage());
+
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponseDto(ErrorCode.INTERNAL_SERVER_ERROR));

--- a/src/main/java/com/dope/breaking/service/FailableUserInformation.java
+++ b/src/main/java/com/dope/breaking/service/FailableUserInformation.java
@@ -1,6 +1,5 @@
 package com.dope.breaking.service;
 
-import com.dope.breaking.exception.CustomInternalErrorException;
 import com.dope.breaking.exception.ErrorCode;
 
 public enum FailableUserInformation {

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -100,7 +100,7 @@ public class PostService {
             }
 
         } catch (Exception e) {
-            throw new CustomInternalErrorException("게시글을 등록할 수 없습니다.");
+            throw new CustomInternalErrorException(e.getMessage());
         }
 
         List<String> mediaURL = new LinkedList<>(); //순서를 지정하기 위함.
@@ -150,7 +150,7 @@ public class PostService {
         } catch (Exception e) {
             log.info("게시글 수정 실패");
             e.printStackTrace();
-            throw new CustomInternalErrorException("게시글을 수정할 수 없습니다.");
+            throw new CustomInternalErrorException(e.getMessage());
         }
         log.info(modifyPost.toString());
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,6 @@ spring:
     password: 1234
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-
-
   jpa:
     hibernate:
       ddl-auto: create
@@ -14,6 +12,7 @@ spring:
       hibernate:
         #        show_sql: true
         format_sql: true
+
   profiles:
     include: jwt
 
@@ -27,12 +26,12 @@ spring:
       max-file-size: 100MB
       max-request-size: 200MB
 
-
   redis:
     host: localhost
     port: 6379
 
-logging.level:
-  org.hibernate.SQL: debug
 
+logging:
+  level:
+    org.hibernate.SQL: debug
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<configuration>
+    <springProperty name="SLACK_WEBHOOK_URI" source="logging.slack.webhook-uri"/>
+    <appender name="SLACK" class="com.github.maricn.logback.SlackAppender">
+        <webhookUri>${SLACK_WEBHOOK_URI}</webhookUri>
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %msg %n</pattern>
+        </layout>
+        <username>Cake-Server-log</username>
+        <iconEmoji>:stuck_out_tongue_winking_eye:</iconEmoji>
+        <colorCoding>true</colorCoding>
+    </appender>
+
+    <!-- Consol appender 설정 -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <Pattern>%d %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC_SLACK" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SLACK"/>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="Console" />
+        <appender-ref ref="ASYNC_SLACK"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #199 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
Internal server error를 slack webhook을 통해 로그화했습니다.
로컬에서는 작동하지 않게, 설정 값을 제거했고,

application.yml 빌드 파일에는 다음 내용이 포함되어있습니다.

```
logging:
  level:
    org.hibernate.SQL: debug
  slack:
    webhook-uri: https://hooks.slack.com/services/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
  config: classpath:logback-spring.xml
```

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/183437574-8292ba93-60b2-43cd-b691-6799ab03fb7a.png)
