### PR TITLE
fix: reply not searched in root comment query

### DIFF
--- a/src/main/java/com/dope/breaking/domain/comment/Comment.java
+++ b/src/main/java/com/dope/breaking/domain/comment/Comment.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.domain.comment;
 
+import com.dope.breaking.domain.baseTimeEntity.BaseTimeEntity;
 import com.dope.breaking.domain.hashtag.Hashtag;
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
@@ -18,7 +19,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Comment {
+public class Comment extends BaseTimeEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column (name="COMMENT_ID")

--- a/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static com.dope.breaking.domain.comment.QComment.comment;
 import static com.dope.breaking.domain.user.QUser.user;
+import static com.querydsl.core.types.ExpressionUtils.and;
 
 @Repository
 public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
@@ -82,7 +83,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
 
         switch (targetType) {
             case POST:
-                return comment.post.id.eq(targetId);
+                return and(comment.post.id.eq(targetId), comment.parent.isNull());
             case COMMENT:
                 return comment.parent.id.eq(targetId);
         }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #205 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에 root comment 조회 시에, 답글도 나와버리는 버그가 있어서 수정했습니다.

답글은 postId 가 null 인줄 알았는데,
postId가 포함되어서 나타난 문제였습니다 ㅠ

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
