### PR TITLE
fix: unify created time to created-date

### DIFF
--- a/src/main/java/com/dope/breaking/domain/comment/Comment.java
+++ b/src/main/java/com/dope/breaking/domain/comment/Comment.java
@@ -54,9 +54,6 @@ public class Comment extends BaseTimeEntity {
 
     private LocalDateTime eventTime;
 
-    @CreatedDate
-    private LocalDateTime createdTime;
-
     @Builder
     public Comment(User user, Post post, String content){
         this.user = user;

--- a/src/main/java/com/dope/breaking/domain/financial/Transaction.java
+++ b/src/main/java/com/dope/breaking/domain/financial/Transaction.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 
 import javax.persistence.*;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -54,10 +54,6 @@ public class Post extends BaseTimeEntity {
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarkList = new ArrayList<Bookmark>();
 
-
-    @CreatedDate
-    private LocalDateTime createdDate;
-
     private String title;
 
     @Column(length = 2500)

--- a/src/main/java/com/dope/breaking/dto/comment/CommentResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/comment/CommentResponseDto.java
@@ -5,7 +5,6 @@ import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.CreatedDate;
 
 import java.time.LocalDateTime;
 
@@ -26,16 +25,16 @@ public class CommentResponseDto {
 
     private Boolean isLiked;
 
-    private LocalDateTime createdTime;
+    private LocalDateTime createdDate;
 
     @QueryProjection
-    public CommentResponseDto(Long commentId, String content, Integer likeCount, Integer replyCount, WriterDto user, Boolean isLiked, LocalDateTime createdTime) {
+    public CommentResponseDto(Long commentId, String content, Integer likeCount, Integer replyCount, WriterDto user, Boolean isLiked, LocalDateTime createdDate) {
         this.commentId = commentId;
         this.content = content;
         this.likeCount = likeCount;
         this.replyCount = replyCount;
         this.user = user;
         this.isLiked = isLiked;
-        this.createdTime = createdTime;
+        this.createdDate = createdDate;
     }
 }

--- a/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
@@ -46,7 +46,7 @@ public class DetailPostResponseDto {
 
 	private LocalDateTime eventTime;
 
-	private LocalDateTime createdTime;
+	private LocalDateTime createdDate;
 
 	private LocalDateTime modifiedTime;
 
@@ -72,7 +72,7 @@ public class DetailPostResponseDto {
 	private boolean isMyPost = false;
 
 	@Builder
-	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked,boolean isPurchased ,WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdTime, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount, int totalCommentCount, boolean isMyPost) {
+	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked,boolean isPurchased ,WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdDate, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount, int totalCommentCount, boolean isMyPost) {
 		this.isLiked = isLiked;
 		this.isBookmarked = isBookmarked;
 		this.isPurchased = isPurchased;
@@ -86,7 +86,7 @@ public class DetailPostResponseDto {
 		this.postType = postType;
 		this.isAnonymous = isAnonymous;
 		this.eventTime = eventTime;
-		this.createdTime = createdTime;
+		this.createdDate = createdDate;
 		this.modifiedTime = modifiedTime;
 		this.viewCount = viewCount;
 		this.isSold = isSold;

--- a/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
@@ -26,12 +26,12 @@ public class FeedResultPostDto {
     private int price;
     private Boolean isLiked;
     private Boolean isBookmarked;
-    private LocalDateTime createdTime;
+    private LocalDateTime createdDate;
 
     @QueryProjection
     public FeedResultPostDto(Long postId, String title, String region, String thumbnailImgURL, int likeCount,
                              PostType postType, Boolean isSold, int viewCount, Long userId, String profileImgURL,
-                             String nickname, int price, Boolean isLiked, Boolean isBookmarked, LocalDateTime createdTime) {
+                             String nickname, int price, Boolean isLiked, Boolean isBookmarked, LocalDateTime createdDate) {
         this.postId = postId;
         this.title = title;
         this.region = region;
@@ -46,7 +46,7 @@ public class FeedResultPostDto {
         this.price = price;
         this.isLiked = isLiked;
         this.isBookmarked = isBookmarked;
-        this.createdTime = createdTime;
+        this.createdDate = createdDate;
     }
 
 }

--- a/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/CommentRepositoryCustomImpl.java
@@ -45,7 +45,7 @@ public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
                                 Expressions.asString("")
                             ),
                             Expressions.asBoolean(false),
-                            comment.createdTime
+                            comment.createdDate
                         ))
                 .from(comment)
                 .leftJoin(comment.user, user)

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -211,7 +211,7 @@ public class PostService {
                 .postType(post.getPostType().getTitle())
                 .isAnonymous(post.isAnonymous())
                 .eventTime(post.getEventTime())
-                .createdTime(post.getCreatedDate())
+                .createdDate(post.getCreatedDate())
                 .modifiedTime(post.getModifiedDate())
                 .viewCount(post.getViewCount())
                 .bookmarkedCount(bookmarkRepository.countByPost(post))


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #207 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
약 한 달 전에 작성된 코드 때문에
created-time과 created-date이 혼용되고 있었는데,
이번에 comment 관련 쿼리 작성하면서 에러가 터졌습니다.

created-date 으로 통일합니다.