### PR TITLE
feat: distinguish request platform with User-Agent

### DIFF
--- a/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
+++ b/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
@@ -21,6 +21,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
@@ -34,8 +36,6 @@ public class JwtAuthenticationAPI {
 
     private final JwtAuthenticationService jwtAuthenticationService;
 
-
-
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/oauth2/validate-jwt")
     public ResponseEntity<UserBriefInformationResponseDto> validateJwt(Principal principal) {
@@ -44,16 +44,15 @@ public class JwtAuthenticationAPI {
 
     @GetMapping("/reissue") //토큰 재발행 부분.
     public ResponseEntity<?> refreshTokenReissue(@RequestHeader(value = "Authorization", required = true) String accessToken,
-                                                 @RequestHeader(value = "Authorization-Refresh", required = true) String refreshToken) throws IOException {
+                                                 @RequestHeader(value = "Authorization-Refresh", required = true) String refreshToken,
+                                                 HttpServletRequest httpServletRequest) throws IOException, ServletException {
 
-        return jwtAuthenticationService.reissue(accessToken, refreshToken);
+        return jwtAuthenticationService.reissue(accessToken, refreshToken, httpServletRequest);
     }
 
-
-    //AcessToken을 받아 무효화 처리를 한다.
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/oauth2/sign-out")
-    public ResponseEntity logout(@RequestHeader(value = "Authorization") String accessToken) throws IOException{
+    public ResponseEntity logout(@RequestHeader(value = "Authorization") String accessToken) throws IOException, ServletException {
         return jwtAuthenticationService.logout(accessToken);
     }
 }

--- a/src/main/java/com/dope/breaking/api/Oauth2LoginAPI.java
+++ b/src/main/java/com/dope/breaking/api/Oauth2LoginAPI.java
@@ -11,6 +11,9 @@ import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
 
@@ -23,19 +26,19 @@ public class Oauth2LoginAPI {
     private final Oauth2LoginService oauth2LoginService;
 
     @PostMapping("/kakao")
-    public ResponseEntity<?> kakaoOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken) throws InvalidAccessTokenException, ParseException {
+    public ResponseEntity<?> kakaoOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
         if(principal != null) throw new AlreadyLoginException();
         String token = accessToken.get("accessToken");
         ResponseEntity<String> kakaoUserinfo = oauth2LoginService.kakaoUserInfo(token);
-        return oauth2LoginService.kakaoLogin(kakaoUserinfo);
+        return oauth2LoginService.kakaoLogin(kakaoUserinfo, httpServletRequest);
     }
 
     @PostMapping("/google")
-    public ResponseEntity<?> googleOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken) throws InvalidAccessTokenException, ParseException {
+    public ResponseEntity<?> googleOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
         if(principal != null) throw new AlreadyLoginException();
         String token = accessToken.get("accessToken");
         String idtoken = accessToken.get("idToken");
         ResponseEntity<String> GoogleUserinfo = oauth2LoginService.googleUserInfo(token, idtoken);
-        return oauth2LoginService.googleLogin(GoogleUserinfo);
+        return oauth2LoginService.googleLogin(GoogleUserinfo, httpServletRequest);
     }
 }

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -13,7 +13,10 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.security.Principal;
 import java.util.*;
 
@@ -24,12 +27,11 @@ public class UserAPI {
     private final UserService userService;
 
 
-
     @GetMapping("/oauth2/sign-up/validate-phone-number/{phoneNumber}")
-    public ResponseEntity<Void> validatePhoneNumber(@PathVariable String phoneNumber, Principal principal){
+    public ResponseEntity<Void> validatePhoneNumber(@PathVariable String phoneNumber, Principal principal) {
 
         String username = null;
-        if(principal != null)  {
+        if (principal != null) {
             username = principal.getName();
         }
         userService.validatePhoneNumber(phoneNumber, username);
@@ -37,10 +39,10 @@ public class UserAPI {
     }
 
     @GetMapping("/oauth2/sign-up/validate-email/{email}")
-    public ResponseEntity<Void> validateEmail(@PathVariable String email, Principal principal){
+    public ResponseEntity<Void> validateEmail(@PathVariable String email, Principal principal) {
 
         String username = null;
-        if(principal != null)  {
+        if (principal != null) {
             username = principal.getName();
         }
         userService.validateEmail(email, username);
@@ -48,10 +50,10 @@ public class UserAPI {
     }
 
     @GetMapping("/oauth2/sign-up/validate-nickname/{nickname}")
-    public ResponseEntity<Void> validateNickname(@PathVariable String nickname, Principal principal){
+    public ResponseEntity<Void> validateNickname(@PathVariable String nickname, Principal principal) {
 
         String username = null;
-        if(principal != null)  {
+        if (principal != null) {
             username = principal.getName();
         }
         userService.validateNickname(nickname, username);
@@ -60,10 +62,10 @@ public class UserAPI {
 
     @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(Principal principal,
-            @RequestPart String signUpRequest,
-            @RequestPart (required = false) List<MultipartFile> profileImg) {
-        if(principal != null) throw new AlreadyLoginException();
-        return userService.signUp(signUpRequest, profileImg);
+                                    @RequestPart String signUpRequest,
+                                    @RequestPart(required = false) List<MultipartFile> profileImg, HttpServletRequest httpServletRequest) throws ServletException, IOException {
+        if (principal != null) throw new AlreadyLoginException();
+        return userService.signUp(signUpRequest, profileImg, httpServletRequest);
     }
 
     @PreAuthorize("isAuthenticated()")
@@ -71,15 +73,14 @@ public class UserAPI {
     public ResponseEntity<?> profileUpdateConfirm(
             Principal principal,
             @RequestPart String updateRequest,
-            @RequestPart (required = false) List<MultipartFile> profileImg) {
+            @RequestPart(required = false) List<MultipartFile> profileImg) {
 
         userService.updateProfile(principal.getName(), updateRequest, profileImg);
         return ResponseEntity.status(HttpStatus.CREATED).build();
-
     }
 
     @GetMapping("/profile/{userId}")
-    public ResponseEntity<ProfileInformationResponseDto> profileInformation(Principal principal, @PathVariable Long userId){
+    public ResponseEntity<ProfileInformationResponseDto> profileInformation(Principal principal, @PathVariable Long userId) {
         String userName = null;
         if (principal != null) {
             userName = principal.getName();
@@ -92,6 +93,4 @@ public class UserAPI {
     public ResponseEntity<FullUserInformationResponse> fullUserInformation(Principal principal) {
         return ResponseEntity.ok().body(userService.getFullUserInformation(principal.getName()));
     }
-
-
 }

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -3,7 +3,7 @@ package com.dope.breaking.exception;
 /**
  * 에러 코드는, 최대한 Exception 클래스의 이름과 동일하게 맞춰주세요.
  * ex) InvalidAccessTokenException.class -> ErrorCode.INVALID_ACCESS_TOKEN
- *
+ * <p>
  * 해당 에러 코드와 라벨은, Notion 문서의 (코드명, 메시지) 와 일치시킵니다.
  */
 public enum ErrorCode {
@@ -13,13 +13,11 @@ public enum ErrorCode {
     EXPIRED_ACCESS_TOKEN("BSE002", "Access Token이 만료되었습니다."),
     INVALID_REFRESH_TOKEN("BSE003", "Refresh Token이 유효하지 않습니다."),
     EXPIRED_REFRESH_TOKEN("BSE004", "Refresh Token이 만료되었습니다."),
-
+    NOT_FOUND_USER_AGENT("BSE006", "User-Agent 정보를 찾을 수 없습니다."),
     ALREADY_LOGIN("BSE010", " 로그인된 유저입니다."),
-
     NO_PERMISSION("BSE005", "해당 기능에 대한 권한이 없습니다."),
     BAD_REQUEST("BSE400", "클라이언트 요청오류."),
     NO_SUCH_USER("BSE401", "해당 유저를 찾을 수 없습니다."),
-
     INVALID_NICKNAME_FORMAT("BSE410", "닉네임 형식이 잘못되었습니다."),
     INVALID_PHONE_NUMBER_FORMAT("BSE411", "전화번호 형식이 잘못되었습니다."),
     INVALID_EMAIL_FORMAT("BSE412", "이메일 형식이 잘못되었습니다."),
@@ -27,10 +25,10 @@ public enum ErrorCode {
     DUPLICATED_NICKNAME("BSE413", "사용중인 닉네임입니다."),
     DUPLICATED_PHONE_NUMBER("BSE414", "사용중인 전화번호입니다."),
     DUPLICATED_EMAIL("BSE415", "사용중인 이메일입니다."),
-    ALREADY_FOLLOWING("BSE420","이미 팔로우 중인 유저입니다."),
-    ALREADY_UNFOLLOWING("BSE421","이미 언팔로우 중인 유저입니다."),
-    NO_SUCH_POST("BSE450","해당 제보를 찾을 수 없습니다."),
-    NO_SUCH_COMMENT("BSE451","해당 댓글을 찾을 수 없습니다."),
+    ALREADY_FOLLOWING("BSE420", "이미 팔로우 중인 유저입니다."),
+    ALREADY_UNFOLLOWING("BSE421", "이미 언팔로우 중인 유저입니다."),
+    NO_SUCH_POST("BSE450", "해당 제보를 찾을 수 없습니다."),
+    NO_SUCH_COMMENT("BSE451", "해당 댓글을 찾을 수 없습니다."),
     PURCHASED_POST("BSE452", "판매된 게시글은 삭제할 수 없습니다."),
     ALREADY_NOT_PURCHASABLE("BSE453","이미 구매 비활성화 된 제보입니다."),
     ALREADY_PURCHASABLE("BSE454","이미 구매 활성화 된 제보입니다."),
@@ -39,16 +37,14 @@ public enum ErrorCode {
     ALREADY_BOOKMARKED("BSE456", "이미 북마크를 선택했습니다."),
 
     ALREADY_UNBOOKMARKED("BSE457", "이미 북마크를 선택하지 않았습니다."),
-    ALREADY_LIKED("BSE458","이미 좋아요를 선택했습니다."),
-    ALREADY_UNLIKED("BSE459","이미 좋아요를 선택하지 않았습니다."),
-    NOT_PURCHASABLE_POST("BSE460","구매 제한이 된 포스트입니다."),
-    SOLD_EXCLUSIVE_POST("BSE461","이미 판매 된 단독제보입니다."),
+    ALREADY_LIKED("BSE458", "이미 좋아요를 선택했습니다."),
+    ALREADY_UNLIKED("BSE459", "이미 좋아요를 선택하지 않았습니다."),
+    NOT_PURCHASABLE_POST("BSE460", "구매 제한이 된 포스트입니다."),
+    SOLD_EXCLUSIVE_POST("BSE461", "이미 판매 된 단독제보입니다."),
 
     INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패."),
 
-    NOT_ENOUGH_BALANCE("BSE601", "금액이 부족합니다.")
-
-    ;
+    NOT_ENOUGH_BALANCE("BSE601", "금액이 부족합니다.");
 
     private String code;
     private String message;
@@ -64,6 +60,8 @@ public enum ErrorCode {
 
     public String getMessage() {
         return message;
-    };
+    }
+
+    ;
 
 }

--- a/src/main/java/com/dope/breaking/exception/auth/NotFoundUserAgent.java
+++ b/src/main/java/com/dope/breaking/exception/auth/NotFoundUserAgent.java
@@ -1,0 +1,12 @@
+package com.dope.breaking.exception.auth;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundUserAgent extends BreakingException {
+
+    public NotFoundUserAgent(){
+        super(ErrorCode.NOT_FOUND_USER_AGENT, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dope/breaking/security/jwt/DistinguishUserAgent.java
+++ b/src/main/java/com/dope/breaking/security/jwt/DistinguishUserAgent.java
@@ -1,0 +1,40 @@
+package com.dope.breaking.security.jwt;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.rmi.server.ServerCloneException;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component //빈 등록
+public class DistinguishUserAgent {
+
+    private final String WEB_BROWSERS_USER_AGENT = "Mozilla";
+
+    private final String ANDROID_USER_AGENT = "Dalvik";
+
+    private final String POSTMAN_USER_AGENT = "PostmanRuntime";
+
+    public String extractUserAgent(String userAgent) throws IOException, ServletException {
+        return distinguishUserAgent(userAgent);
+    }
+
+    private String distinguishUserAgent(String userAgent){
+        if(userAgent.startsWith(WEB_BROWSERS_USER_AGENT)){
+            return "WEB";
+        }else if (userAgent.startsWith(ANDROID_USER_AGENT)){
+            return "ANDROID";
+        }else if(userAgent.startsWith(POSTMAN_USER_AGENT)){
+            return "POSTMAN";
+        }else {
+            return"OTHER";
+        }
+    }
+
+}

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -18,6 +18,9 @@ import java.util.*;
 @Component //빈 등록
 public class JwtTokenProvider {
 
+    private final DistinguishUserAgent distinguishUserAgent;
+
+
     @Value("${jwt.secret}")
     private String secret;
 
@@ -35,12 +38,13 @@ public class JwtTokenProvider {
         secret = Base64.getEncoder().encodeToString(secret.getBytes());
     }
 
-    public String createAccessToken(String username) {
+    public String createAccessToken(String username, String userAgent) {
         Claims claims = Jwts.claims().setSubject(username); // JWT payload 에 저장되는 정보단위
         Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
                 .setIssuer("AccessToken")
+                .setAudience(userAgent)
                 .setIssuedAt(now) // 토큰 발행 시간 정보
                 .setExpiration(new Date(now.getTime() + accesstokenValidityInMilliseconds)) // set Expire Time
                 .signWith(SignatureAlgorithm.HS256, secret)  // 사용할 암호화 알고리즘과 signature 에 들어갈 secret값 세팅
@@ -52,7 +56,6 @@ public class JwtTokenProvider {
         Date now = new Date();
         return Jwts.builder()
                 //토큰 종류 지정
-
                 .setClaims(claims) //유저이름 지정.
                 .setIssuer("RefreshToken")
                 .setIssuedAt(now)
@@ -94,6 +97,11 @@ public class JwtTokenProvider {
     public String getTokenType(String token){
         String tokenType = Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody().getIssuer();
         return tokenType;
+    }
+
+    public String getUserAgent(String token){
+        String userAgent = Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody().getAudience();
+        return userAgent;
     }
 
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #177 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 웹브라우저와 안드로이드 앱의 로그인 요청 구별을 구현하였습니다. 플랫폼 별, User-Agent의 정보는 다음과 같습니다. 
- Web : Mozilla/5.0 ~
- Android : Dalvik/2.1.0 ~

따라서 헤더에 담긴 User-Agent 정보를 판별하여 웹/앱의 요청을 구별합니다. 

2. User-Agent가 필요한 부분은 Jwt토큰을 발행하는 부분입니다. 
- 로그인 요청(카카오, 구글)
- 재발행 요청
- 회원가입 요청

3. 로그아웃의 경우,Access 토큰에 User-Agent로 부터 추출된 정보를 페이로드에 담아두었기에, 필요하지 않습니다. 

4. 테스트코드를 통하여 이상없음을 확인하였습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="764" alt="스크린샷 2022-08-09 오후 4 49 45" src="https://user-images.githubusercontent.com/62254434/183594637-57876c40-f76b-4524-802d-2f24344c8430.png">

<img width="766" alt="스크린샷 2022-08-09 오후 4 25 56" src="https://user-images.githubusercontent.com/62254434/183594686-16b1e09c-acc8-44d0-95c2-f4640050d34b.png">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
