### PR TITLE
feat: add isPurchasable field in post

### DIFF
--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -73,7 +73,7 @@ public class Post extends BaseTimeEntity {
 
     private boolean isHidden;
 
-    private boolean isPurchasable = true;
+    private Boolean isPurchasable = true;
 
     private LocalDateTime eventTime;
 

--- a/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/DetailPostResponseDto.java
@@ -71,8 +71,10 @@ public class DetailPostResponseDto {
 
 	private boolean isMyPost = false;
 
+	private Boolean isPurchasable = true;
+
 	@Builder
-	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked,boolean isPurchased ,WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdDate, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount, int totalCommentCount, boolean isMyPost) {
+	public DetailPostResponseDto(boolean isLiked, boolean isBookmarked,boolean isPurchased ,WriterDto user, String title, String content, List<String> hashtagList, List<String> mediaList, LocationDto location, int price, String postType, boolean isAnonymous, LocalDateTime eventTime, LocalDateTime createdDate, LocalDateTime modifiedTime, int viewCount, boolean isSold, int soldCount, int bookmarkedCount, boolean isHidden, int likeCount, int totalCommentCount, boolean isMyPost, Boolean isPurchasable) {
 		this.isLiked = isLiked;
 		this.isBookmarked = isBookmarked;
 		this.isPurchased = isPurchased;
@@ -96,6 +98,7 @@ public class DetailPostResponseDto {
 		this.likeCount = likeCount;
 		this.totalCommentCount = totalCommentCount;
 		this.isMyPost = isMyPost;
+		this.isPurchasable = isPurchasable;
 	}
 }
 

--- a/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
@@ -26,12 +26,14 @@ public class FeedResultPostDto {
     private int price;
     private Boolean isLiked;
     private Boolean isBookmarked;
+    private Boolean isPurchasable;
     private LocalDateTime createdDate;
 
     @QueryProjection
     public FeedResultPostDto(Long postId, String title, String region, String thumbnailImgURL, int likeCount,
                              PostType postType, Boolean isSold, int viewCount, Long userId, String profileImgURL,
-                             String nickname, int price, Boolean isLiked, Boolean isBookmarked, LocalDateTime createdDate) {
+                             String nickname, int price, Boolean isLiked, Boolean isBookmarked, Boolean isPurchasable,
+                             LocalDateTime createdDate) {
         this.postId = postId;
         this.title = title;
         this.region = region;
@@ -46,6 +48,7 @@ public class FeedResultPostDto {
         this.price = price;
         this.isLiked = isLiked;
         this.isBookmarked = isBookmarked;
+        this.isPurchasable = isPurchasable;
         this.createdDate = createdDate;
     }
 

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -80,6 +80,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                         post.price,
                         Expressions.asBoolean(false),
                         Expressions.asBoolean(false),
+                        post.isPurchasable,
                         post.createdDate
                 ))
                 .from(post)
@@ -134,6 +135,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                         post.price,
                         Expressions.asBoolean(false),
                         Expressions.asBoolean(false),
+                        post.isPurchasable,
                         post.createdDate
                 ))
                 .from(post)

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -221,6 +221,7 @@ public class PostService {
                 .isHidden(post.isHidden())
                 .totalCommentCount(commentRepository.countByPost(post))
                 .isMyPost(isMyPost)
+                .isPurchasable(post.getIsPurchasable())
                 .build();
 
         return detailPostResponseDto;
@@ -262,7 +263,7 @@ public class PostService {
             throw new NoPermissionException();
         }
 
-        if(!post.isPurchasable()){
+        if(!post.getIsPurchasable()){
             throw new AlreadyNotPurchasableException();
         }
 
@@ -280,7 +281,7 @@ public class PostService {
             throw new NoPermissionException();
         }
 
-        if(post.isPurchasable()){
+        if(post.getIsPurchasable()){
             throw new AlreadyPurchasableException();
         }
 

--- a/src/main/java/com/dope/breaking/service/PurchaseService.java
+++ b/src/main/java/com/dope/breaking/service/PurchaseService.java
@@ -40,7 +40,7 @@ public class PurchaseService {
 
         User seller = post.getUser();
 
-        if (!post.isPurchasable()) {
+        if (!post.getIsPurchasable()) {
             throw new NotPurchasablePostException();
         }
 

--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -572,7 +572,7 @@ class PostAPITest {
                 .andExpect(status().isOk()); //Then
 
         //Then
-        Assertions.assertTrue(post.isPurchasable());
+        Assertions.assertTrue(post.getIsPurchasable());
 
     }
 
@@ -653,7 +653,7 @@ class PostAPITest {
                 .andExpect(status().isOk()); //Then
 
         //Then
-        Assertions.assertFalse(post.isPurchasable());
+        Assertions.assertFalse(post.getIsPurchasable());
 
     }
 

--- a/src/test/java/com/dope/breaking/service/PostServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostServiceTest.java
@@ -527,7 +527,7 @@ class PostServiceTest {
         postService.activatePurchase("12345g", post.getId());
 
         //then
-        Assertions.assertTrue(post.isPurchasable());
+        Assertions.assertTrue(post.getIsPurchasable());
 
     }
 
@@ -584,7 +584,7 @@ class PostServiceTest {
         postService.deactivatePurchase("12345g", post.getId());
 
         //then
-        Assertions.assertFalse(post.isPurchasable());
+        Assertions.assertFalse(post.getIsPurchasable());
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #209 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- feed 조회에 ispurchasable 필드 추가
- class Boolean type으로 변경

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/183783342-1ef1066a-a17e-434d-9ee7-c9b3b7cc8509.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

DTO, Entity 에서 booelan 타입 사용 시에, primitive type 보다는 class type으로 하는게 좋은 것 같습니다.
- getter setter 에서 get, set 불필요하게 생략됨
- response로 사용할 경우,  추가 작업을 해줘야함