### PR TITLE
feat: change the key value of the JWT header to lowercase

### DIFF
--- a/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
+++ b/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
@@ -43,8 +43,8 @@ public class JwtAuthenticationAPI {
     }
 
     @GetMapping("/reissue") //토큰 재발행 부분.
-    public ResponseEntity<?> refreshTokenReissue(@RequestHeader(value = "Authorization", required = true) String accessToken,
-                                                 @RequestHeader(value = "Authorization-Refresh", required = true) String refreshToken,
+    public ResponseEntity<?> refreshTokenReissue(@RequestHeader(value = "authorization", required = true) String accessToken,
+                                                 @RequestHeader(value = "authorization-refresh", required = true) String refreshToken,
                                                  HttpServletRequest httpServletRequest) throws IOException, ServletException {
 
         return jwtAuthenticationService.reissue(accessToken, refreshToken, httpServletRequest);
@@ -52,7 +52,7 @@ public class JwtAuthenticationAPI {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/oauth2/sign-out")
-    public ResponseEntity logout(@RequestHeader(value = "Authorization") String accessToken) throws IOException, ServletException {
+    public ResponseEntity logout(@RequestHeader(value = "authorization") String accessToken) throws IOException, ServletException {
         return jwtAuthenticationService.logout(accessToken);
     }
 }

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -24,8 +24,8 @@ public class JwtTokenProvider {
     @Value("${jwt.secret}")
     private String secret;
 
-    private final String accessHeader = "Authorization";
-    private final String refreshHeader = "Authorization-Refresh";
+    private final String accessHeader = "authorization";
+    private final String refreshHeader = "authorization-Refresh";
 
     private static final String BEARER = "Bearer ";
 

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -25,7 +25,7 @@ public class JwtTokenProvider {
     private String secret;
 
     private final String accessHeader = "authorization";
-    private final String refreshHeader = "authorization-Refresh";
+    private final String refreshHeader = "authorization-refresh";
 
     private static final String BEARER = "Bearer ";
 

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -61,9 +61,9 @@ public class JwtAuthenticationService {
             }
 
             HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", jwtTokenProvider.createAccessToken(username, userAgentType));
+            httpHeaders.set("authorization", jwtTokenProvider.createAccessToken(username, userAgentType));
             String newRefrsehToken = jwtTokenProvider.createRefreshToken(username);
-            httpHeaders.set("Authorization-Refresh", newRefrsehToken);
+            httpHeaders.set("authorization-refresh", newRefrsehToken);
             redisService.setDataWithExpiration(userAgentType + "_" + username, newRefrsehToken, 2 * 604800L);
 
             return ResponseEntity.status(HttpStatus.OK).headers(httpHeaders).build();

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -102,8 +102,8 @@ public class Oauth2LoginService {
             String accessToken = jwtTokenProvider.createAccessToken(dto.getUsername(), userAgentType);
             String refreshToken = jwtTokenProvider.createRefreshToken(dto.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", accessToken);
-            httpHeaders.set("Authorization-Refresh", refreshToken);
+            httpHeaders.set("authorization", accessToken);
+            httpHeaders.set("authorization-refresh", refreshToken);
             redisService.setDataWithExpiration(userAgentType + "_" +dto.getUsername(), refreshToken,2 * 604800L);
             User user = userRepository.findByUsername(dto.getUsername()).get();
             UserBriefInformationResponseDto userBriefInformationResponseDto  = UserBriefInformationResponseDto.builder()
@@ -175,8 +175,8 @@ public class Oauth2LoginService {
             String accessToken = jwtTokenProvider.createAccessToken(dto.getUsername(), userAgentType);
             String refreshToken = jwtTokenProvider.createRefreshToken(dto.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
-            httpHeaders.set("Authorization", accessToken);
-            httpHeaders.set("Authorization-Refresh", refreshToken);
+            httpHeaders.set("authorization", accessToken);
+            httpHeaders.set("authorization-refresh", refreshToken);
             redisService.setDataWithExpiration(userAgentType + "_" + dto.getUsername(), refreshToken, 2 * 604800L);
             User user = userRepository.findByUsername(dto.getUsername()).get();
             UserBriefInformationResponseDto userBriefInformationResponseDto = UserBriefInformationResponseDto.builder()

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -89,9 +89,9 @@ public class UserService {
 
         HttpHeaders httpHeaders = new HttpHeaders();
         String userAgentType = distinguishUserAgent.extractUserAgent(userAgent);
-        httpHeaders.set("Authorization", jwtTokenProvider.createAccessToken(signUpRequestDto.getUsername(), userAgentType));
+        httpHeaders.set("authorization", jwtTokenProvider.createAccessToken(signUpRequestDto.getUsername(), userAgentType));
         String refreshjwt = jwtTokenProvider.createRefreshToken(signUpRequestDto.getUsername());
-        httpHeaders.set("Authorization-Refresh", refreshjwt);
+        httpHeaders.set("authorization-refresh", refreshjwt);
         redisService.setDataWithExpiration(userAgentType + "_" + signUpRequestDto.getUsername(), refreshjwt, 2 * 604800L); //리플리쉬 토큰 redis에 저장.
 
         UserBriefInformationResponseDto userBriefInformationResponseDto = UserBriefInformationResponseDto.builder()


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #211 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에는 JWT가 발급되었을 때, 첫문자가 대문자였습니다. 하지만 웹/앱의 클라이언트측에서 모두 소문자로 구성된 key값이 반환되었기에, 혼용을방지하고자 서버쪽도 소문자로 변경합니다. 따라서 소문자로 응답 및 요청이 이루어 집니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="762" alt="스크린샷 2022-08-10 오후 1 00 35" src="https://user-images.githubusercontent.com/62254434/183810086-ab6a7636-acd1-4240-9b5b-852ce827274b.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
알고보니 서버쪽이나 클라이언트쪽이나, key값의 대소문자 구별을 따로 두지 않는 것 같습니다. 키값 수정 후, 소문자 및 대문자를 혼용하여 테스트를 진행하였는데 모두 통과된 것으로 보아, ignoreIsCase가 적용되는 것 같습니다. 