### PR TITLE
feat: http only cookie to refresh token when Web

### DIFF
--- a/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
+++ b/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
@@ -44,10 +44,10 @@ public class JwtAuthenticationAPI {
 
     @GetMapping("/reissue") //토큰 재발행 부분.
     public ResponseEntity<?> refreshTokenReissue(@RequestHeader(value = "authorization", required = true) String accessToken,
-                                                 @RequestHeader(value = "authorization-refresh", required = true) String refreshToken,
-                                                 HttpServletRequest httpServletRequest) throws IOException, ServletException {
+                                                 @RequestHeader(value = "authorization-refresh", required = false) String refreshToken,
+                                                 HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws IOException, ServletException {
 
-        return jwtAuthenticationService.reissue(accessToken, refreshToken, httpServletRequest);
+        return jwtAuthenticationService.reissue(accessToken, refreshToken, httpServletRequest, httpServletResponse);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/dope/breaking/api/Oauth2LoginAPI.java
+++ b/src/main/java/com/dope/breaking/api/Oauth2LoginAPI.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Map;
@@ -26,19 +27,19 @@ public class Oauth2LoginAPI {
     private final Oauth2LoginService oauth2LoginService;
 
     @PostMapping("/kakao")
-    public ResponseEntity<?> kakaoOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
+    public ResponseEntity<?> kakaoOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
         if(principal != null) throw new AlreadyLoginException();
         String token = accessToken.get("accessToken");
         ResponseEntity<String> kakaoUserinfo = oauth2LoginService.kakaoUserInfo(token);
-        return oauth2LoginService.kakaoLogin(kakaoUserinfo, httpServletRequest);
+        return oauth2LoginService.kakaoLogin(kakaoUserinfo, httpServletRequest, httpServletResponse);
     }
 
     @PostMapping("/google")
-    public ResponseEntity<?> googleOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
+    public ResponseEntity<?> googleOauthLogin(Principal principal, @RequestBody Map<String, String> accessToken, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws InvalidAccessTokenException, ParseException, ServletException, IOException {
         if(principal != null) throw new AlreadyLoginException();
         String token = accessToken.get("accessToken");
         String idtoken = accessToken.get("idToken");
         ResponseEntity<String> GoogleUserinfo = oauth2LoginService.googleUserInfo(token, idtoken);
-        return oauth2LoginService.googleLogin(GoogleUserinfo, httpServletRequest);
+        return oauth2LoginService.googleLogin(GoogleUserinfo, httpServletRequest, httpServletResponse);
     }
 }

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -63,9 +63,9 @@ public class UserAPI {
     @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(Principal principal,
                                     @RequestPart String signUpRequest,
-                                    @RequestPart(required = false) List<MultipartFile> profileImg, HttpServletRequest httpServletRequest) throws ServletException, IOException {
+                                    @RequestPart(required = false) List<MultipartFile> profileImg, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
         if (principal != null) throw new AlreadyLoginException();
-        return userService.signUp(signUpRequest, profileImg, httpServletRequest);
+        return userService.signUp(signUpRequest, profileImg, httpServletRequest, httpServletResponse);
     }
 
     @PreAuthorize("isAuthenticated()")

--- a/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
@@ -11,9 +11,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) { //CORS 정책 추가.
         registry.addMapping("/**")
-                .allowedOrigins("*")
+                .allowedOrigins("http://localhost:8080", "https://team-dope.link:8443", "http://localhost:3000", "https://localhost:3000")
                 .allowedMethods("*")
                 .allowedHeaders("*")
-                .exposedHeaders("*");
+                .exposedHeaders("*")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
@@ -25,6 +25,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @Configuration //빈으로 등록
@@ -85,10 +87,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("*");
+        configuration.setAllowedOrigins(List.of("http://localhost:8080", "https://team-dope.link:8443", "http://localhost:3000", "https://localhost:3000"));
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.addExposedHeader("*");
+        configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dope/breaking/security/jwt/JwtTokenProvider.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.*;
@@ -72,6 +73,19 @@ public class JwtTokenProvider {
 
     public Optional<String> extractAccessToken(String request) throws IOException {
         return Optional.ofNullable(request).filter(refreshToken -> refreshToken.startsWith(BEARER)).map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    public String extractRefreshTokenFromCookie(HttpServletRequest httpServletRequest) throws IOException{
+        Cookie[] cookies = httpServletRequest.getCookies();
+        if(cookies == null){
+            return null;
+        }
+        for(Cookie cookie : cookies){
+            if(cookie.getName().equals("authorization-refresh")){
+                return cookie.getValue();
+            }
+        }
+        return null;
     }
 
 

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -68,7 +68,6 @@ public class JwtAuthenticationService {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("authorization", jwtTokenProvider.createAccessToken(username, userAgentType));
             String newRefrsehToken = jwtTokenProvider.createRefreshToken(username);
-            httpHeaders.set("authorization-refresh", newRefrsehToken);
             if(userAgentType.equals("WEB")) {
                 Cookie cookie = new Cookie("authorization-refresh", newRefrsehToken);
                 cookie.setMaxAge(2 * 24 * 60 * 60); //2주

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -70,7 +70,7 @@ public class JwtAuthenticationService {
             String newRefrsehToken = jwtTokenProvider.createRefreshToken(username);
             if(userAgentType.equals("WEB")) {
                 Cookie cookie = new Cookie("authorization-refresh", newRefrsehToken);
-                cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+                cookie.setMaxAge(14 * 24 * 60 * 60); //2주
                 cookie.setHttpOnly(true);
                 cookie.setPath("/");
                 httpServletResponse.addCookie(cookie);

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -107,7 +107,7 @@ public class Oauth2LoginService {
             httpHeaders.set("authorization", accessToken);
             if(userAgentType.equals("WEB")) {
                 Cookie cookie = new Cookie("authorization-refresh", refreshToken);
-                cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+                cookie.setMaxAge(14 * 24 * 60 * 60); //2주
                 cookie.setHttpOnly(true);
                 cookie.setPath("/");
                 httpServletResponse.addCookie(cookie);
@@ -193,7 +193,7 @@ public class Oauth2LoginService {
             httpHeaders.set("authorization-refresh", refreshToken);
             if(userAgentType.equals("WEB")) {
                 Cookie cookie = new Cookie("authorization-refresh", refreshToken);
-                cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+                cookie.setMaxAge(14 * 24 * 60 * 60); //2주
                 cookie.setHttpOnly(true);
                 cookie.setPath("/");
                 httpServletResponse.addCookie(cookie);

--- a/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
+++ b/src/main/java/com/dope/breaking/service/Oauth2LoginService.java
@@ -18,7 +18,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Optional;
 
@@ -59,7 +61,7 @@ public class Oauth2LoginService {
         return kakaoUserinfo;
     }
 
-    public ResponseEntity<?> kakaoLogin(ResponseEntity<String> kakaoUserinfo, HttpServletRequest httpServletRequest) throws ParseException, ServletException, IOException {
+    public ResponseEntity<?> kakaoLogin(ResponseEntity<String> kakaoUserinfo, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ParseException, ServletException, IOException {
         String userAgent = Optional.ofNullable(httpServletRequest.getHeader("User-Agent")).orElseThrow( () -> new NotFoundUserAgent());
         log.info(userAgent);
         JSONParser jsonParser = new JSONParser();
@@ -103,7 +105,19 @@ public class Oauth2LoginService {
             String refreshToken = jwtTokenProvider.createRefreshToken(dto.getUsername());
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("authorization", accessToken);
-            httpHeaders.set("authorization-refresh", refreshToken);
+            if(userAgentType.equals("WEB")) {
+                Cookie cookie = new Cookie("authorization-refresh", refreshToken);
+                cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+                cookie.setHttpOnly(true);
+                cookie.setPath("/");
+                httpServletResponse.addCookie(cookie);
+            }
+            else{
+                httpHeaders.set("authorization-refresh", refreshToken);
+            }
+
+
+
             redisService.setDataWithExpiration(userAgentType + "_" +dto.getUsername(), refreshToken,2 * 604800L);
             User user = userRepository.findByUsername(dto.getUsername()).get();
             UserBriefInformationResponseDto userBriefInformationResponseDto  = UserBriefInformationResponseDto.builder()
@@ -138,7 +152,7 @@ public class Oauth2LoginService {
 
 
 
-    public ResponseEntity<?> googleLogin(ResponseEntity<String> GoogleUserinfo, HttpServletRequest httpServletRequest) throws ParseException, ServletException, IOException {
+    public ResponseEntity<?> googleLogin(ResponseEntity<String> GoogleUserinfo, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ParseException, ServletException, IOException {
         String userAgent = Optional.ofNullable(httpServletRequest.getHeader("User-Agent")).orElseThrow( () -> new NotFoundUserAgent());
 
         JSONParser jsonParser = new JSONParser();
@@ -177,6 +191,18 @@ public class Oauth2LoginService {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.set("authorization", accessToken);
             httpHeaders.set("authorization-refresh", refreshToken);
+            if(userAgentType.equals("WEB")) {
+                Cookie cookie = new Cookie("authorization-refresh", refreshToken);
+                cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+                cookie.setHttpOnly(true);
+                cookie.setPath("/");
+                httpServletResponse.addCookie(cookie);
+            }
+            else{
+                httpHeaders.set("authorization-refresh", refreshToken);
+            }
+
+
             redisService.setDataWithExpiration(userAgentType + "_" + dto.getUsername(), refreshToken, 2 * 604800L);
             User user = userRepository.findByUsername(dto.getUsername()).get();
             UserBriefInformationResponseDto userBriefInformationResponseDto = UserBriefInformationResponseDto.builder()

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -95,7 +95,7 @@ public class UserService {
         String refreshjwt = jwtTokenProvider.createRefreshToken(signUpRequestDto.getUsername());
         if(userAgentType.equals("WEB")) {
             Cookie cookie = new Cookie("authorization-refresh", refreshjwt);
-            cookie.setMaxAge(2 * 24 * 60 * 60); //2주
+            cookie.setMaxAge(14 * 24 * 60 * 60); //2주
             cookie.setHttpOnly(true);
             cookie.setPath("/");
             httpServletResponse.addCookie(cookie);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #221 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. User-Agent정보가 Mozilla/5.x로 시작하는 웹 브라우저일 경우 HttpOnly 쿠키로 refresh 토큰을 담아 클라이언트에게 응답합니다. 
 - Xss 위협으로부터 방지할 수 있을것으로 기대합니다.

2. Cors 설정에 Credential을 추가하였습니다. 여러 기술블로그를 참고하니, HttpOnly 쿠키를 사용하기 위해서 필수라고 합니다. 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
1. 웹에서 로그인 할 시 쿠키에 refresh 토큰이 담김
<img width="1836" alt="스크린샷 2022-08-11 오후 3 56 53" src="https://user-images.githubusercontent.com/62254434/184080125-cc79914a-5d28-4b67-a30a-8c22beb92303.png">

2. 웹에서 재발급 요청을 할 시 refresh토큰이 쿠키로 재발급 됨
<img width="1703" alt="스크린샷 2022-08-11 오후 3 58 59" src="https://user-images.githubusercontent.com/62254434/184080249-949b5f0e-e2fb-4586-aa64-13710b27b093.png">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
우선, 서버에 배포 후, cors 문제 및 브라우저에 쿠키가 잘 담아지는지 확인한 후, 문제가 발생 시 수정해 나가는 식으로 진행하겠습니다.