### PR TITLE
feat: implement searching posts by string

### DIFF
--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -50,6 +50,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 .leftJoin(post.postLikeList, postLike)
                 .where(
                         post.isHidden.eq(false),
+                        keyWordSearch(searchFeedConditionDto.getSearchKeyword()),
                         soldOption(searchFeedConditionDto.getSoldOption()),
                         period(searchFeedConditionDto.getDateFrom(), searchFeedConditionDto.getDateTo()),
                         cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
@@ -105,6 +106,15 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
         }
 
         return content;
+    }
+
+    private Predicate keyWordSearch(String searchString) {
+
+        if(searchString == null) {
+            return null;
+        } else {
+            return ExpressionUtils.or(post.title.contains(searchString), post.content.contains(searchString));
+        }
     }
 
     @Override

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -43,6 +43,10 @@ public class SearchFeedService {
             searchFeedConditionDto.setDateTo(LocalDateTime.now());
         }
 
+        if(searchFeedConditionDto.getSearchKeyword() != null) {
+            searchFeedConditionDto.setSearchKeyword(searchFeedConditionDto.getSearchKeyword().replace('+', ' '));
+        }
+
         List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
         for(FeedResultPostDto dto: result) {
             if(dto.getIsAnonymous()) {

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -208,4 +208,90 @@ public class FeedRepositoryTest {
         assertTrue(result.get(0).getIsMyPost());
     }
 
+    @DisplayName("문자열이 포함된 제목이나 본문을 가진 게시글을 검색한다")
+    @Test
+    void searchPostByString() {
+
+        User user = new User();
+        userRepository.save(user);
+
+        Post post = Post.builder()
+                .title("깻묵은 오늘도 맑음 뒤 흐림")
+                .content("본문 없음")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        post = Post.builder()
+                .title("제목이 없음")
+                .content("안녕하세요 테스트 글입니다.")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        post = Post.builder()
+                .title("제목이 없음")
+                .content("본문 없음")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        em.flush();
+
+        List<String> immutableList = List.of("one", "two", "three");
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(3L)
+                .soldOption(SoldOption.ALL)
+                .searchKeywordList(immutableList)
+                .build();
+
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+        assertEquals(2, result.size());
+    }
+
+    @DisplayName("띄어쓰기가 포함된 문자열은 그대로 검색된다.")
+    @Test
+    void searchPostByStringWithSpace() {
+
+        User user = new User();
+        userRepository.save(user);
+
+        Post post = Post.builder()
+                .title("깻묵은 오늘도 맑음 뒤 흐림")
+                .content("본문 없음")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        post = Post.builder()
+                .title("제목이 없음")
+                .content("안녕하세요 테스트 글입니다.")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        post = Post.builder()
+                .title("제목이 없음")
+                .content("본문 없음")
+                .build();
+        post.setUser(user);
+        postRepository.save(post);
+
+        em.flush();
+
+        List<String> immutableList = List.of("one", "two", "three")
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(3L)
+                .soldOption(SoldOption.ALL)
+                .searchKeywordList(immutableList)
+                .build();
+
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+        assertEquals(2, result.size());
+    }
+
 }

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -224,7 +224,7 @@ public class FeedRepositoryTest {
 
         post = Post.builder()
                 .title("제목이 없음")
-                .content("안녕하세요 테스트 글입니다.")
+                .content("안녕하세요? 깻묵입니다. 잘 지내시죠?")
                 .build();
         post.setUser(user);
         postRepository.save(post);
@@ -238,13 +238,11 @@ public class FeedRepositoryTest {
 
         em.flush();
 
-        List<String> immutableList = List.of("one", "two", "three");
-
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
                 .size(3L)
                 .soldOption(SoldOption.ALL)
-                .searchKeywordList(immutableList)
+                .searchKeyword("깻묵")
                 .build();
 
         List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
@@ -267,7 +265,7 @@ public class FeedRepositoryTest {
 
         post = Post.builder()
                 .title("제목이 없음")
-                .content("안녕하세요 테스트 글입니다.")
+                .content("본문 없음")
                 .build();
         post.setUser(user);
         postRepository.save(post);
@@ -281,17 +279,15 @@ public class FeedRepositoryTest {
 
         em.flush();
 
-        List<String> immutableList = List.of("one", "two", "three")
-
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
                 .builder()
                 .size(3L)
                 .soldOption(SoldOption.ALL)
-                .searchKeywordList(immutableList)
+                .searchKeyword("오늘도 맑음")
                 .build();
 
         List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
-        assertEquals(2, result.size());
+        assertEquals(1, result.size());
     }
 
 }

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -225,4 +225,28 @@ public class FeedServiceTest {
         assertNull(result.get(0).getUser());
 
     }
+
+    @DisplayName("+로 입력받은 문자열을 공백으로 replace하여 피드를 검색한다.")
+    @Test
+    void searchWithString() {
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .userPageFeedOption(UserPageFeedOption.WRITE)
+                .searchKeyword("좋은+아침")
+                .build();
+
+        List<FeedResultPostDto> dummy = new ArrayList<>();
+        FeedResultPostDto content = new FeedResultPostDto();
+        content.setIsAnonymous(false);
+        dummy.add(content);
+
+        given(feedRepository.searchFeedBy(searchFeedConditionDto, null, null)).willReturn(dummy);
+
+        //when
+        feedService.searchMainFeed(searchFeedConditionDto, null, null);
+
+        //then
+        assertEquals("좋은 아침", searchFeedConditionDto.getSearchKeyword());
+
+    }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #224 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 문자열 검색 기능을 구현하였습니다.
- 제목에 해당 키워드가 포함되어 있으면 검색됩니다.
- 본문에 해당 키워드가 있으면 검색됩니다.(그러나 피드에서는 본문을 보여주지는 않음)
- 공백은 + 를 통해 구분합니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/184281137-efa75544-7507-4dbd-8f7a-afe592014da5.png)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
현재는 단어를 기반으로 검색이 되지는 않지만,
추후에 elasticsearch 로 이를 구현할 예정입니다.