### PR TITLE
feat: post like list pagination

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostLikeAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostLikeAPI.java
@@ -32,8 +32,15 @@ public class PostLikeAPI {
     }
 
     @GetMapping("post/{postId}/like-list")
-    public ResponseEntity<List<ForListInfoResponseDto>> likedUserList (Principal principal, @PathVariable Long postId){
-        return ResponseEntity.ok().body(postLikeService.likedUserList(principal, postId));
+    public ResponseEntity<List<ForListInfoResponseDto>> likedUserList (Principal principal,
+                                                                       @PathVariable Long postId,
+                                                                       @RequestParam(value = "cursor")
+                                                                                   Long cursorId, @RequestParam(value = "size") int size){
+        String username =  null;
+        if(principal != null){ username = principal.getName(); }
+
+        return ResponseEntity.ok().body(postLikeService.postLikeList(username,postId,cursorId,size));
+
     }
 
 }

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -27,6 +27,8 @@ public enum ErrorCode {
     DUPLICATED_EMAIL("BSE415", "사용중인 이메일입니다."),
     ALREADY_FOLLOWING("BSE420", "이미 팔로우 중인 유저입니다."),
     ALREADY_UNFOLLOWING("BSE421", "이미 언팔로우 중인 유저입니다."),
+    INVALID_CURSOR("BSE440", "유효하지 않은 cursor입니다."),
+
     NO_SUCH_POST("BSE450", "해당 제보를 찾을 수 없습니다."),
     NO_SUCH_COMMENT("BSE451", "해당 댓글을 찾을 수 없습니다."),
     PURCHASED_POST("BSE452", "판매된 게시글은 삭제할 수 없습니다."),

--- a/src/main/java/com/dope/breaking/exception/pagination/InvalidCursorException.java
+++ b/src/main/java/com/dope/breaking/exception/pagination/InvalidCursorException.java
@@ -1,0 +1,11 @@
+package com.dope.breaking.exception.pagination;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class InvalidCursorException extends BreakingException {
+
+    public InvalidCursorException() {super(ErrorCode.INVALID_CURSOR,HttpStatus.BAD_REQUEST);}
+
+}

--- a/src/main/java/com/dope/breaking/repository/PostLikeRepository.java
+++ b/src/main/java/com/dope/breaking/repository/PostLikeRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PostLikeRepository extends JpaRepository<PostLike,Long> {
+public interface PostLikeRepository extends JpaRepository<PostLike,Long>, PostLikeRepositoryCustom {
 
     boolean existsPostLikesByUserAndPost(User user, Post post);
 

--- a/src/main/java/com/dope/breaking/repository/PostLikeRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/PostLikeRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.ForListInfoResponseDto;
+
+import java.util.List;
+
+public interface PostLikeRepositoryCustom {
+
+    public List<ForListInfoResponseDto> postLikeList(User me, Post post, Long cursorId, int size);
+
+}

--- a/src/main/java/com/dope/breaking/repository/PostLikeRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/PostLikeRepositoryCustomImpl.java
@@ -1,0 +1,70 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.ForListInfoResponseDto;
+import com.dope.breaking.dto.user.QForListInfoResponseDto;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+
+import java.util.List;
+
+import static com.dope.breaking.domain.post.QPostLike.postLike;
+import static com.dope.breaking.domain.user.QUser.user;
+
+
+@Repository
+public class PostLikeRepositoryCustomImpl implements  PostLikeRepositoryCustom{
+
+    private final UserRepository userRepository;
+    private final JPAQueryFactory queryFactory;
+    private final FollowRepository followRepository;
+
+    public PostLikeRepositoryCustomImpl(@Lazy UserRepository userRepository, @Lazy EntityManager em, @Lazy FollowRepository followRepository) {
+        this.userRepository = userRepository;
+        this.queryFactory = new JPAQueryFactory(em);
+        this.followRepository = followRepository;
+    }
+
+    @Override
+    public List<ForListInfoResponseDto> postLikeList(User me, Post post, Long cursorId, int size){
+
+        List<ForListInfoResponseDto> content = queryFactory
+                .select(new QForListInfoResponseDto(
+                        postLike.id,
+                        postLike.user.id,
+                        postLike.user.nickname,
+                        postLike.user.statusMsg,
+                        postLike.user.compressedProfileImgURL
+                ))
+                .from(postLike)
+                .leftJoin(postLike.user,user)
+                .where(
+                        cursorPagination(cursorId),
+                        postLike.post.eq(post)
+                )
+                .limit(size)
+                .fetch();
+
+        if(me != null) {
+            for(ForListInfoResponseDto forListInfoResponseDto : content) {
+                forListInfoResponseDto.setFollowing(followRepository.existsFollowsByFollowedAndFollowing(userRepository.findById(forListInfoResponseDto.getUserId()).get(), me));
+            }
+        }
+
+        return content;
+    }
+
+
+    private Predicate cursorPagination(Long cursorId) {
+        if(cursorId == null || cursorId == 0) {
+            return null;
+        }
+        return postLike.id.gt(cursorId);
+    }
+
+}

--- a/src/main/java/com/dope/breaking/service/FollowService.java
+++ b/src/main/java/com/dope/breaking/service/FollowService.java
@@ -7,6 +7,7 @@ import com.dope.breaking.dto.user.ForListInfoResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.follow.AlreadyFollowingException;
 import com.dope.breaking.exception.follow.AlreadyUnfollowingException;
+import com.dope.breaking.exception.pagination.InvalidCursorException;
 import com.dope.breaking.exception.user.NoSuchUserException;
 import com.dope.breaking.repository.FollowRepository;
 import com.dope.breaking.repository.UserRepository;
@@ -62,10 +63,22 @@ public class FollowService {
         }
         User selectedUser = userRepository.findById(userId).orElseThrow(NoSuchUserException::new);
 
+        if(cursorId != null && cursorId != 0L){
+            if(!followRepository.existsById(cursorId)){
+                throw new InvalidCursorException();
+            }
+        }
+
         if(followTargetType == FollowTargetType.FOLLOWING) {
+            if(followRepository.getById(cursorId).getFollowing()!=selectedUser){
+                throw new InvalidCursorException();
+            }
             return followRepository.followingList(me, selectedUser, cursorId, size);
         }
         else if(followTargetType == FollowTargetType.FOLLOWED) {
+            if(followRepository.getById(cursorId).getFollowed()!=selectedUser){
+                throw new InvalidCursorException();
+            }
             return followRepository.followerList(me, selectedUser, cursorId, size);
         }
 

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -5,6 +5,7 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.pagination.InvalidCursorException;
 import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.exception.user.LoginRequireException;
 import com.dope.breaking.exception.user.NoPermissionException;
@@ -35,7 +36,7 @@ public class SearchFeedService {
 
         Post cursorPost = null;
         if(cursorId != null && cursorId != 0) {
-            cursorPost = postRepository.findById(cursorId).orElseThrow(NoSuchPostException::new);
+            cursorPost = postRepository.findById(cursorId).orElseThrow(InvalidCursorException::new);
         }
 
         if(searchFeedConditionDto.getForLastMin() != null) {
@@ -79,7 +80,7 @@ public class SearchFeedService {
 
         Post cursorPost = null;
         if(cursorId != null && cursorId != 0) {
-            cursorPost = postRepository.findById(cursorId).orElseThrow(NoSuchPostException::new);
+            cursorPost = postRepository.findById(cursorId).orElseThrow(InvalidAccessTokenException::new);
         }
 
         return feedRepository.searchUserPageBy(searchFeedConditionDto, owner, me, cursorPost);

--- a/src/test/java/com/dope/breaking/api/PostLikeAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostLikeAPITest.java
@@ -135,30 +135,4 @@ class PostLikeAPITest {
 
     }
 
-    @Test
-    @WithMockCustomUser
-    void likedUserList() throws Exception{
-
-        //Given
-        User user1 = new User();
-        User user2 = new User();
-        Post post = new Post();
-
-        userRepository.save(user1);
-        userRepository.save(user2);
-        postRepository.save(post);
-
-        postLikeService.likePost(user1,post);
-        postLikeService.likePost(user2,post);
-
-        followService.follow("12345g",user1.getId());
-
-        //When
-        this.mockMvc.perform(get("/post/{postId}/like-list",post.getId()))
-                .andExpect(status().isOk()) //Then
-                .andExpect(jsonPath("$[0].isFollowing").value(true))
-                .andExpect(jsonPath("$[1].isFollowing").value(false))
-                .andExpect(jsonPath("$", hasSize(2)));
-    }
-
 }

--- a/src/test/java/com/dope/breaking/repository/PostLikeRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/PostLikeRepositoryTest.java
@@ -2,7 +2,10 @@ package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.user.Follow;
+import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.ForListInfoResponseDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -10,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import javax.transaction.Transactional;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -20,6 +25,7 @@ public class PostLikeRepositoryTest {
     @Autowired UserRepository userRepository;
     @Autowired PostRepository postRepository;
     @Autowired PostLikeRepository postLikeRepository;
+    @Autowired FollowRepository followRepository;
 
     @DisplayName("유저가 좋아요를 한 게시물이면, true가 반한된다.")
     @Test
@@ -34,4 +40,32 @@ public class PostLikeRepositoryTest {
 
         assertTrue(postLikeRepository.existsByUserAndPostId(user, post.getId()));
     }
+
+    @DisplayName("유저가 좋아요 한 사람 리스트를 조회할 경우, 팔로우 여부가 정확히 반환 된다")
+    @Test
+    void postLikeList(){
+
+        User user1 = new User();
+        user1.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username1", Role.USER);
+        User user2 = new User();
+        user2.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username2", Role.USER);
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Post post = new Post();
+        postRepository.save(post);
+
+        PostLike postLike1 = new PostLike(user1, post);
+        PostLike postLike2 = new PostLike(user2, post);
+        postLikeRepository.save(postLike1);
+        postLikeRepository.save(postLike2);
+
+        Follow follow = new Follow(user1,user2);
+        followRepository.save(follow);
+
+        Assertions.assertFalse(postLikeRepository.postLikeList(user1,post,null,10).get(0).isFollowing());
+        Assertions.assertTrue(postLikeRepository.postLikeList(user1,post,null,10).get(1).isFollowing());
+
+    }
+
 }

--- a/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/PostLikeServiceTest.java
@@ -1,17 +1,26 @@
 package com.dope.breaking.service;
 
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.user.Follow;
+import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.exception.pagination.InvalidCursorException;
+import com.dope.breaking.repository.FollowRepository;
 import com.dope.breaking.repository.PostLikeRepository;
 import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
-import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
+
+import static org.junit.jupiter.api.Assertions.*;
+
 
 @SpringBootTest
 @Transactional
@@ -21,6 +30,7 @@ class PostLikeServiceTest {
     @Autowired private PostLikeRepository postLikeRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private PostRepository postRepository;
+    @Autowired private FollowRepository followRepository;
     @Autowired private EntityManager entityManager;
 
     @Test
@@ -43,10 +53,9 @@ class PostLikeServiceTest {
         entityManager.clear();
 
         //Then
-        Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post1)).isTrue();
-        Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post2)).isTrue();
-        Assertions.assertThat(postRepository.findById(post1.getId()).get().getPostLikeList().size()).isEqualTo(1);
-
+        Assertions.assertTrue(postLikeRepository.existsPostLikesByUserAndPost(user,post1));
+        Assertions.assertTrue(postLikeRepository.existsPostLikesByUserAndPost(user,post2));
+        Assertions.assertEquals(1,postRepository.findById(post1.getId()).get().getPostLikeList().size());
 
     }
 
@@ -72,8 +81,8 @@ class PostLikeServiceTest {
         entityManager.clear();
 
         //Then
-        Assertions.assertThat(postLikeRepository.existsPostLikesByUserAndPost(user,post)).isFalse();
-        Assertions.assertThat(postRepository.findById(post.getId()).get().getPostLikeList().size()).isEqualTo(0);
+        Assertions.assertFalse(postLikeRepository.existsPostLikesByUserAndPost(user,post));
+        Assertions.assertEquals(0,postRepository.findById(post.getId()).get().getPostLikeList().size());
 
     }
 
@@ -99,8 +108,8 @@ class PostLikeServiceTest {
         entityManager.clear();
 
         //Then
-        Assertions.assertThat(postLikeRepository.countPostLikesByUser(user)).isEqualTo(0);
-        Assertions.assertThat(postRepository.findById(post1.getId()).get().getPostLikeList().size()).isEqualTo(0);
+        Assertions.assertEquals(0,postLikeRepository.countPostLikesByUser(user));
+        Assertions.assertEquals(0,postRepository.findById(post1.getId()).get().getPostLikeList().size());
 
     }
 
@@ -124,28 +133,74 @@ class PostLikeServiceTest {
         entityManager.flush();
 
         //Then
-        Assertions.assertThat(postLikeRepository.countPostLikesByPost(post)).isEqualTo(0);
+        Assertions.assertEquals(0,postLikeRepository.countPostLikesByPost(post));
 
     }
 
+
+    @DisplayName("cursorId가 유효하지 않은 경우, 예외가 발생한다.")
     @Test
-    void likedUserList(){
+    void purchaseListWithInvalidCursorId(){
 
         //Given
         User user1 = new User();
+        user1.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username1", Role.USER);
         User user2 = new User();
-        Post post = new Post();
-
+        user2.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username2", Role.USER);
         userRepository.save(user1);
         userRepository.save(user2);
-        postRepository.save(post);
 
-        //When
-        postLikeService.likePost(user1,post);
-        postLikeService.likePost(user2,post);
+        Post post = new Post();
+        postRepository.save(post);
+        Post post2 = new Post();
+        postRepository.save(post2);
+
+        PostLike postLike1 = new PostLike(user1, post);
+        PostLike postLike2 = new PostLike(user2, post);
+        PostLike postLike3 = new PostLike(user2, post2);
+        postLikeRepository.save(postLike1);
+        postLikeRepository.save(postLike3);
+        postLikeRepository.save(postLike2);
+
+        Follow follow = new Follow(user1,user2);
+        followRepository.save(follow);
 
         //Then
-        Assertions.assertThat(postLikeService.likedUserList(null,post.getId()).size()).isEqualTo(2);
+        Assertions.assertThrows(InvalidCursorException.class,
+                ()->postLikeService.postLikeList(user1.getUsername(),post.getId(),100L,10)); //When
+
+        Assertions.assertThrows(InvalidCursorException.class,
+                ()->postLikeService.postLikeList(user1.getUsername(),post.getId(),2L,10)); //When
+
+    }
+
+    @DisplayName("cursorId와 유저네임이 유효한 경우, 좋아요한 사람의 리스트가 정확히 반환된다.")
+    @Test
+    void purchaseListWithValidCursorIdAndUsername(){
+
+        //Given
+        User user1 = new User();
+        user1.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username1", Role.USER);
+        User user2 = new User();
+        user2.setRequestFields("URL", "anyURL", "nickname", "01012345678", "mwk300@nyu.edu", "Minwu Kim", "msg", "username2", Role.USER);
+        userRepository.save(user1);
+        userRepository.save(user2);
+
+        Post post = new Post();
+        postRepository.save(post);
+
+        PostLike postLike1 = new PostLike(user1, post);
+        PostLike postLike2 = new PostLike(user2, post);
+        postLikeRepository.save(postLike1);
+        postLikeRepository.save(postLike2);
+
+        Follow follow = new Follow(user1,user2);
+        followRepository.save(follow);
+
+        //Then                                       //When
+        org.junit.jupiter.api.Assertions.assertFalse(postLikeService.postLikeList(user1.getUsername(),post.getId(),null,10).get(0).isFollowing());
+        org.junit.jupiter.api.Assertions.assertTrue(postLikeService.postLikeList(user1.getUsername(),post.getId(),null,10).get(1).isFollowing());
+
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #236 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 제보 좋아요한 사람 리스트에 페이지네이션을 구현했습니다.
- InvalidCursorException을 추가했습니다. 아래의 두가지 경우에 발생합니다.
   - 존재하지 않은 커서일 경우
   - 해당 제보에 대한 postLike의 id가 아닐 경우
- 이에 맞게 테스트코드를 작성했습니다. 


## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 아직 approve 되지 않은 구매자리스트에도 InvalidCursorException을 추가할 예정입니다.
