### PR TITLE
feat: add breaking mission creation method

### DIFF
--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -1,0 +1,30 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.service.MissionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.security.Principal;
+
+@RestController
+@RequiredArgsConstructor
+public class MissionAPI {
+
+    private final MissionService missionService;
+
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping("/breaking-mission")
+    public ResponseEntity createMission(Principal principal, @RequestBody @Valid MissionRequestDto missionRequestDto){
+
+        missionService.createMission(missionRequestDto, principal.getName());
+        return ResponseEntity.ok().build();
+
+    }
+
+}

--- a/src/main/java/com/dope/breaking/dto/mission/MissionRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/mission/MissionRequestDto.java
@@ -1,0 +1,40 @@
+package com.dope.breaking.dto.mission;
+
+import com.dope.breaking.dto.post.LocationDto;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MissionRequestDto {
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private String content;
+
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.SCALAR, pattern = "yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startTime;
+
+    @NotNull
+    @JsonFormat(shape = JsonFormat.Shape.SCALAR, pattern = "yyyy-MM-dd HH:mm:ss")
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime endTime;
+
+    @JsonProperty("location") //locationDto에 location이라는 이름으로 된, key 값을 받음.
+    @Valid
+    private LocationDto locationDto;
+
+}

--- a/src/main/java/com/dope/breaking/dto/post/PostRequestDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/PostRequestDto.java
@@ -1,6 +1,5 @@
 package com.dope.breaking.dto.post;
 
-import com.dope.breaking.domain.post.Post;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -44,6 +44,9 @@ public enum ErrorCode {
     NOT_PURCHASABLE_POST("BSE460", "구매 제한이 된 포스트입니다."),
     SOLD_EXCLUSIVE_POST("BSE461", "이미 판매 된 단독제보입니다."),
 
+    MISSION_ONLY_FOR_PRESS("BSE481", "브레이킹 미션은 언론사만 게시 가능합니다."),
+
+
     INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패."),
 
     NOT_ENOUGH_BALANCE("BSE601", "금액이 부족합니다.");

--- a/src/main/java/com/dope/breaking/exception/post/MissionOnlyForPressException.java
+++ b/src/main/java/com/dope/breaking/exception/post/MissionOnlyForPressException.java
@@ -1,0 +1,13 @@
+package com.dope.breaking.exception.post;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class MissionOnlyForPressException extends BreakingException {
+
+    public MissionOnlyForPressException() {super(ErrorCode.MISSION_ONLY_FOR_PRESS, HttpStatus.BAD_REQUEST);}
+
+}
+
+

--- a/src/main/java/com/dope/breaking/repository/MissionRepository.java
+++ b/src/main/java/com/dope/breaking/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/src/main/java/com/dope/breaking/service/MissionService.java
+++ b/src/main/java/com/dope/breaking/service/MissionService.java
@@ -1,0 +1,51 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.post.Location;
+import com.dope.breaking.domain.post.Mission;
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.post.MissionOnlyForPressException;
+import com.dope.breaking.repository.MissionRepository;
+import com.dope.breaking.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MissionService {
+
+    private final MissionRepository missionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createMission(MissionRequestDto missionRequestDto, String username){
+
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+
+        if(user.getRole() == Role.USER){
+            throw new MissionOnlyForPressException();
+        }
+
+        Location location = new Location(
+                missionRequestDto.getLocationDto().getAddress(),
+                missionRequestDto.getLocationDto().getLongitude(),
+                missionRequestDto.getLocationDto().getLatitude(),
+                missionRequestDto.getLocationDto().getRegion_1depth_name(),
+                missionRequestDto.getLocationDto().getRegion_2depth_name());
+
+        Mission mission = new Mission(
+                user,
+                missionRequestDto.getTitle(),
+                missionRequestDto.getContent(),
+                missionRequestDto.getStartTime(),
+                missionRequestDto.getEndTime(),
+                location);
+
+        missionRepository.save(mission);
+
+    }
+
+}

--- a/src/test/java/com/dope/breaking/api/MissionAPITest.java
+++ b/src/test/java/com/dope/breaking/api/MissionAPITest.java
@@ -1,0 +1,170 @@
+package com.dope.breaking.api;
+
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.dto.post.LocationDto;
+import com.dope.breaking.repository.MissionRepository;
+import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+class MissionAPITest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+
+    @DisplayName("언론사가 브레이킹 미션을 게시할 경우, 미션이 정상적으로 게시 된다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void createMissionByPress() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.PRESS);
+        userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",startTime, endTime, locationDto);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(missionRequestDto);
+
+        //When
+        this.mockMvc.perform(post("/breaking-mission")
+                        .content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk()); //Then
+
+        //Then
+        Assertions.assertEquals(1, missionRepository.findAll().size());
+
+    }
+
+    @DisplayName("언론사가 아닌 개인유저가 브레이킹 미션을 게시할 경우, 예외가 발생한다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void createMissionNotByPress() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.USER);
+        userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",startTime, endTime, locationDto);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(missionRequestDto);
+
+        //When
+        this.mockMvc.perform(post("/breaking-mission")
+                        .content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest()); //Then
+
+    }
+
+    @DisplayName("유효한 유저네임이 아닐 경우, 예외가 발생한다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void createMissionWithInvalidUsername() throws Exception {
+
+        //Given
+        User user = new User("anotherUsername",passwordEncoder.encode(UUID.randomUUID().toString()), Role.PRESS);
+        userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",startTime, endTime, locationDto);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(missionRequestDto);
+
+        //When
+        this.mockMvc.perform(post("/breaking-mission")
+                        .content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized()); //Then
+
+    }
+
+    @DisplayName("미션 게시 요청에 누락된 필드가 있을 경우, 예외가 발생한다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void createMissionWithNullField() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.PRESS);
+        userRepository.save(user);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1",null);
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",startTime, endTime, locationDto);
+
+        objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, false);
+        ObjectWriter ow = objectMapper.writer().withDefaultPrettyPrinter();
+        String requestJson = ow.writeValueAsString(missionRequestDto);
+
+        //When
+        this.mockMvc.perform(post("/breaking-mission")
+                        .content(requestJson)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest()); //Then
+
+    }
+
+}

--- a/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
@@ -1,0 +1,43 @@
+package com.dope.breaking.repository;
+
+import com.dope.breaking.domain.post.Location;
+import com.dope.breaking.domain.post.Mission;
+import com.dope.breaking.domain.user.User;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MissionRepositoryTest {
+
+    @Autowired MissionRepository missionRepository;
+    @Autowired UserRepository userRepository;
+
+    @DisplayName("브레이킹 미션을 생성할 시, 미션이 정상적으로 저장된다.")
+    @Test
+    void createMission(){
+
+        //Given
+        User user = new User();
+        userRepository.save(user);
+
+        Location location = new Location("full address", 10.0, 10.0, "depth1", "depth2");
+        Mission mission = new Mission(user,"title","content",null,null,location);
+
+        //When
+        Long missionId = missionRepository.save(mission).getId();
+
+        //Then
+        Assertions.assertEquals(1, missionRepository.findAll().size());
+        Assertions.assertEquals(user,missionRepository.findById(missionId).get().getUser());
+
+    }
+
+}

--- a/src/test/java/com/dope/breaking/service/MissionServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/MissionServiceTest.java
@@ -1,0 +1,100 @@
+package com.dope.breaking.service;
+
+import com.dope.breaking.domain.user.Role;
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.dto.post.LocationDto;
+import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.post.MissionOnlyForPressException;
+import com.dope.breaking.repository.MissionRepository;
+import com.dope.breaking.repository.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MissionServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private MissionRepository missionRepository;
+
+    @InjectMocks
+    private MissionService missionService;
+
+    @DisplayName("사용자가 언론사일 경우, 브레이킹미션이 생성된다.")
+    @Test
+    void createMissionByPress() {
+
+        //Given
+        User user = new User("username","password", Role.PRESS);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content", startTime, endTime, locationDto);
+
+        //When
+        when(userRepository.findByUsername("username")).thenReturn(Optional.of(user));
+
+        //Then
+        missionService.createMission(missionRequestDto,"username");
+
+    }
+
+    @DisplayName("사용자가 언론사가 아닐 경우, 예외가 발생한다.")
+    @Test
+    void createMissionNotByPress() {
+
+        //Given
+        User user = new User("username","password", Role.USER);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",startTime,endTime, locationDto);
+
+        //When
+        when(userRepository.findByUsername("username")).thenReturn(Optional.of(user));
+
+        //Then
+        Assertions.assertThrows(MissionOnlyForPressException.class,
+                () -> missionService.createMission(missionRequestDto,"username"));
+
+    }
+
+    @DisplayName("유저네임이 무효할 경우, 예외가 발생한다.")
+    @Test
+    void createMissionWithInvalidUsername() {
+
+        //Given
+        User user = new User("username","password", Role.USER);
+
+        LocalDateTime startTime = LocalDateTime.of(2022, Month.AUGUST, 16, 19, 30, 40);
+        LocalDateTime endTime = LocalDateTime.of(2022, Month.AUGUST, 20, 19, 30, 40);
+
+        LocationDto locationDto = new LocationDto("full address",10.0,10.0,"depth1","depth2");
+        MissionRequestDto missionRequestDto = new MissionRequestDto("title","content",null,null, locationDto);
+
+        //Then
+        Assertions.assertThrows(InvalidAccessTokenException.class,
+                () -> missionService.createMission(missionRequestDto,"username1")); //When
+
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #241 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 브레이킹미션 게시 기능을 추가했습니다.
  - 브레이킹미션은 언론사만 게시 가능합니다. 일반 유저가 미션을 게시할 경우 예외가 발생합니다. 
  - 프론트에서 보내오는 요청의 모든 필드는 null 값을 불허합니다. null 값이 있을 경우 예외가 발생합니다. 
- 이에 맞는 테스트코드를 작성했습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 브레이킹 미션 수행을 위한 제보 생성 기능을 구현하겠습니다. 