### PR TITLE
feat: implement searching user by string

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -2,6 +2,8 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.dto.user.ProfileInformationResponseDto;
+import com.dope.breaking.dto.user.SearchUserResponseDto;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SearchFeedService;
 import com.dope.breaking.service.SortStrategy;
@@ -85,6 +87,21 @@ public class FeedAPI {
 
         return ResponseEntity.ok().body(searchFeedService.searchUserFeed(searchFeedConditionDto, ownerId, username, cursorId));
 
+    }
+
+    @GetMapping("/search/user")
+    public ResponseEntity<List<SearchUserResponseDto>> searchUser(
+            Principal principal,
+            @PathVariable(value = "search") String searchKeyword,
+            @PathVariable(value = "cursor") Long cursorId,
+            @PathVariable(value = "size") Long size
+    ) {
+
+        String username = null;
+        if (principal != null) {
+            username = principal.getName();
+        }
+        return ResponseEntity.ok().body(searchFeedService.searchUser(username, searchKeyword, cursorId, size));
     }
 
 }

--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -92,9 +92,9 @@ public class FeedAPI {
     @GetMapping("/search/user")
     public ResponseEntity<List<SearchUserResponseDto>> searchUser(
             Principal principal,
-            @PathVariable(value = "search") String searchKeyword,
-            @PathVariable(value = "cursor") Long cursorId,
-            @PathVariable(value = "size") Long size
+            @RequestParam(value = "search") String searchKeyword,
+            @RequestParam(value = "cursor") Long cursorId,
+            @RequestParam(value = "size") Long size
     ) {
 
         String username = null;

--- a/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
@@ -1,0 +1,38 @@
+package com.dope.breaking.dto.user;
+
+import com.dope.breaking.domain.user.Role;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Setter;
+
+@Data
+@Setter
+public class SearchUserResponseDto {
+
+    Long userId;
+
+    String profileImgURL;
+
+    String nickname;
+
+    String email;
+
+    String statusMsg;
+
+    Role role;
+
+    Boolean isFollowing;
+
+    @Builder
+    @QueryProjection
+    public SearchUserResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, Boolean isFollowing) {
+        this.userId = userId;
+        this.profileImgURL = profileImgURL;
+        this.nickname = nickname;
+        this.email = email;
+        this.statusMsg = statusMsg;
+        this.role = role;
+        this.isFollowing = isFollowing;
+    }
+}

--- a/src/main/java/com/dope/breaking/repository/UserRepository.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository extends JpaRepository<User,Long> {
+public interface UserRepository extends JpaRepository<User,Long>, UserRepositoryCustom {
 
     Optional<User> findByUsername(String username);
     Optional<User> findByNickname(String nickname);

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustom.java
@@ -1,4 +1,11 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.SearchUserResponseDto;
+
+import java.util.List;
+
 public interface UserRepositoryCustom {
+
+    List<SearchUserResponseDto> searchUserBy(User me, String searchKeyword, User cursorUser, Long size);
 }

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.dope.breaking.repository;
+
+public interface UserRepositoryCustom {
+}

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
@@ -1,4 +1,66 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.QSearchUserResponseDto;
+import com.dope.breaking.dto.user.SearchUserResponseDto;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static com.dope.breaking.domain.comment.QComment.comment;
+import static com.dope.breaking.domain.user.QFollow.follow;
+import static com.dope.breaking.domain.user.QUser.user;
+
+@Repository
 public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserRepositoryCustomImpl(EntityManager em) {
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<SearchUserResponseDto> searchUserBy(User me, String searchKeyword, User cursorUser, Long size) {
+
+        return queryFactory
+                .select(new QSearchUserResponseDto(
+                        user.id,
+                        user.compressedProfileImgURL,
+                        user.nickname,
+                        user.email,
+                        user.statusMsg,
+                        user.role,
+                        isFollowing(me)
+                ))
+                .from(user)
+                .leftJoin(user.followerList, follow)
+                .where(
+                        cursorPagination(cursorUser),
+                        user.nickname.contains(searchKeyword)
+                )
+                .limit(size)
+                .fetch();
+    }
+
+    private Predicate isFollowing(User me) {
+
+        if(me == null) {
+            return Expressions.asBoolean(false);
+        } else {
+            return follow.following.eq(me);
+        }
+    }
+
+    private Predicate cursorPagination(User cursorUser) {
+        if(cursorUser == null) {
+            return null;
+        } else {
+            return user.id.gt(cursorUser.getId());
+        }
+    }
 }

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
@@ -1,0 +1,4 @@
+package com.dope.breaking.repository;
+
+public class UserRepositoryCustomImpl implements UserRepositoryCustom {
+}

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -4,6 +4,8 @@ import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
+import com.dope.breaking.dto.user.ProfileInformationResponseDto;
+import com.dope.breaking.dto.user.SearchUserResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.pagination.InvalidCursorException;
 import com.dope.breaking.exception.post.NoSuchPostException;
@@ -87,4 +89,18 @@ public class SearchFeedService {
 
     }
 
+    public List<SearchUserResponseDto> searchUser(String username, String searchKeyword, Long cursorId, Long size) {
+
+        User me = null;
+        if (username != null) {
+            me = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        }
+
+        User cursorUser = null;
+        if(cursorId != null && cursorId != 0L) {
+            cursorUser = userRepository.findById(cursorId).orElseThrow(InvalidCursorException::new);
+        }
+
+        return userRepository.searchUserBy(me, searchKeyword, cursorUser, size);
+    }
 }

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -1,20 +1,30 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.user.Follow;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
+import com.dope.breaking.dto.user.SearchUserResponseDto;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 @SpringBootTest
 @Transactional
 class UserRepositoryTest {
 
-    @Autowired
-    UserRepository userRepository;
+    @Autowired UserRepository userRepository;
+    @Autowired FollowRepository followRepository;
+    @Autowired EntityManager em;
 
     @Test
     void findByNickname() {
@@ -22,31 +32,16 @@ class UserRepositoryTest {
         //Given
         User user = new User();
         user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username", Role.USER);
+        userRepository.save(user);
 
         //When
-        User savedUser = userRepository.save(user);
-        User foundUser = userRepository.findByNickname(savedUser.getNickname()).get();
+        User foundUser = userRepository.findByNickname(user.getNickname()).get();
 
         //Then
-        Assertions.assertThat(foundUser).isEqualTo(savedUser);
+        assertEquals(user, foundUser);
 
     }
 
-//    @Test
-//    void findByPhoneNumber() {
-//
-//        //Given
-//        User user = new User();
-//        user.setRequestFields("URL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
-//
-//        //When
-//        User savedUser = userService.save(user);
-//        User foundUser = userService.findByPhoneNumber(savedUser.getPhoneNumber()).get();
-//
-//        //Then
-//        Assertions.assertThat(foundUser).isEqualTo(savedUser);
-//
-//    }
 
     @Test
     void findByEmail() {
@@ -54,13 +49,66 @@ class UserRepositoryTest {
         //Given
         User user = new User();
         user.setRequestFields("URL","anyURL","nickname", "01012345678","mwk300@nyu.edu","Minwu Kim","msg","username",Role.USER);
+        userRepository.save(user);
 
         //When
-        User savedUser = userRepository.save(user);
-        User foundUser = userRepository.findByEmail(savedUser.getEmail()).get();
+        User foundUser = userRepository.findByEmail(user.getEmail()).get();
 
         //Then
-        Assertions.assertThat(foundUser).isEqualTo(savedUser);
+        assertEquals(user, foundUser);
+
+    }
+
+    @DisplayName("유저 닉네임을 pagination으로 검색한다.")
+    @Test
+    void searchUserByUserNickname() {
+
+        User user1 = new User();
+        user1.setRequestFields("URL", "anyURL", "테스트닉네임1", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(user1);
+
+        User user2 = new User();
+        user2.setRequestFields("URL", "anyURL", "테스트닉네임2", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(user2);
+
+        User user3 = new User();
+        user3.setRequestFields("URL", "anyURL", "테스트닉네임3", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(user3);
+
+        em.flush();
+
+        List<SearchUserResponseDto> result1 = userRepository.searchUserBy(null, "테스트닉네임", null, 2L);
+
+        User cursorUser = userRepository.findById(result1.get(1).getUserId()).get();
+        List<SearchUserResponseDto> result2 = userRepository.searchUserBy(null, "테스트닉네임", cursorUser, 2L);
+
+        assertEquals(2, result1.size());
+        assertEquals(1, result2.size());
+
+        assertEquals(user3.getId(), result2.get(0).getUserId());
+
+    }
+
+    @DisplayName("유저 검색 시, 팔로잉 중인 유저는 isFolowing이 true로 반환된다.")
+    @Test
+    void isFollowingSearchedUser() {
+
+        User me = new User();
+        me.setRequestFields("URL", "anyURL", "테스트닉네임1", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(me);
+
+        User followingUser = new User();
+        followingUser.setRequestFields("URL", "anyURL", "테스트닉네임2", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(followingUser);
+
+        Follow follow = new Follow(me, followingUser);
+        followRepository.save(follow);
+
+        em.flush();
+
+        List<SearchUserResponseDto> result = userRepository.searchUserBy(me, "테스트닉네임2", null, 2L);
+
+        assertTrue(result.get(0).getIsFollowing());
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #234 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
querydsl 으로 유저 검색 기능을 제공합니다.
feedService에 구현을 했는데, 추후에 해당 카테고리를 searchService 리팩토링 예정이라 이렇게 작성했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

![image](https://user-images.githubusercontent.com/76773202/184853989-32a9b5ed-997d-4a7f-97b9-02798d4aa268.png)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

Service Layer Mocking 테스트 관련해서 조금 의문이 있기는 한데,

일단 우아한테크코스 팀의 코드를 참고했을때도 다음을 고려하고 테스트를 작성하는 것 같습니다.
1. exception 없이 정상 동작하는가
2. exception 이 정상적으로 발생하는가
3. 추가로 비즈니스 로직이 있다면, 잘 작동하는가

Unit 테스트에 대해서 조금 더 공부가 필요해보입니다.