### PR TITLE
refactor: feed query tuning with dynamic join

### DIFF
--- a/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/FeedResultPostDto.java
@@ -2,6 +2,7 @@ package com.dope.breaking.dto.post;
 
 import com.dope.breaking.domain.post.PostType;
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -31,6 +32,7 @@ public class FeedResultPostDto {
     private Boolean isBookmarked;
 
     @QueryProjection
+    @Builder
     public FeedResultPostDto(Long postId, String title, LocationDto location, String thumbnailImgURL, int likeCount, int commentCount, PostType postType, int viewCount, WriterDto user, int price, LocalDateTime createdDate, Boolean isPurchasable, Boolean isSold, Boolean isAnonymous, Boolean isMyPost, Boolean isLiked, Boolean isBookmarked) {
         this.postId = postId;
         this.title = title;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -11,6 +11,12 @@ public interface FeedRepositoryCustom {
 
     List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
 
+    List<FeedResultPostDto> searchFeedByHashtag(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
+
+    List<FeedResultPostDto> searchUserPageByBookmark(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
+
+    List<FeedResultPostDto> searchUserPageByPurchase(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
+
     List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
 
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -1,92 +1,270 @@
 package com.dope.breaking.repository;
 
-import com.dope.breaking.domain.comment.Comment;
+import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
-import com.dope.breaking.dto.comment.CommentResponseDto;
-import com.dope.breaking.dto.comment.QCommentResponseDto;
-import com.dope.breaking.dto.comment.SearchCommentConditionDto;
-import com.dope.breaking.dto.post.QWriterDto;
-import com.dope.breaking.service.CommentTargetType;
-import com.querydsl.core.types.Predicate;
+import com.dope.breaking.dto.post.*;
+import com.dope.breaking.service.SoldOption;
+import com.dope.breaking.service.SortStrategy;
+import com.dope.breaking.service.UserPageFeedOption;
+import com.querydsl.core.types.*;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPQLQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.dope.breaking.domain.comment.QComment.comment;
+import static com.dope.breaking.domain.financial.QPurchase.purchase;
+import static com.dope.breaking.domain.hashtag.QHashtag.*;
+import static com.dope.breaking.domain.post.QPostLike.*;
+import static com.dope.breaking.domain.post.QPost.post;
+import static com.dope.breaking.domain.user.QBookmark.bookmark;
 import static com.dope.breaking.domain.user.QUser.user;
-import static com.querydsl.core.types.ExpressionUtils.and;
 
 @Repository
-public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
+public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
-    private final CommentLikeRepository commentLikeRepository;
 
-    public CommentRepositoryCustomImpl(EntityManager em, CommentLikeRepository commentLikeRepository) {
+    public FeedRepositoryCustomImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
-        this.commentLikeRepository = commentLikeRepository;
     }
 
-    @Override
-    public List<CommentResponseDto> searchCommentList(User me, SearchCommentConditionDto searchCommentConditionDto, Comment cursorComment) {
-
-        List<CommentResponseDto> content = queryFactory
-                .select(new QCommentResponseDto(
-                            comment.id,
-                            comment.content,
-                            comment.commentLikeList.size(),
-                            comment.children.size(),
-                            new QWriterDto(
+    private JPQLQuery<FeedResultPostDto> getBaseQuery(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me) {
+        return queryFactory
+                .select(Projections.constructor(FeedResultPostDto.class,
+                        post.id,
+                        post.title,
+                        Projections.constructor(LocationDto.class,
+                                post.location.address,
+                                post.location.longitude,
+                                post.location.latitude,
+                                post.location.region_1depth_name,
+                                post.location.region_2depth_name
+                        ),
+                        post.thumbnailImgURL,
+                        post.postLikeList.size(),
+                        Expressions.asNumber(0),
+                        post.postType,
+                        post.viewCount,
+                        Projections.constructor(WriterDto.class,
                                 user.id,
                                 user.compressedProfileImgURL,
                                 user.nickname
-                            ),
-                            Expressions.asBoolean(false),
-                            comment.createdDate
+                        ),
+                        post.price,
+                        post.createdDate,
+                        post.isPurchasable,
+                        post.isSold,
+                        post.isAnonymous,
+                        me == null ? Expressions.asBoolean(false) : post.user.eq(me), //isMyPost
+                        Expressions.asBoolean(false), //isLiked
+                        Expressions.asBoolean(false) //isBookmarked
                         ))
-                .from(comment)
-                .leftJoin(comment.user, user)
+                .from(post)
+                .leftJoin(post.user, user)
+                .leftJoin(post.postLikeList, postLike)
                 .where(
-                        target(searchCommentConditionDto.getTargetType(), searchCommentConditionDto.getTargetId()),
-                        cursorPagination(cursorComment)
+                        soldOption(searchFeedConditionDto.getSoldOption()),
+                        cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
+                        sameLevelCursorFilter(cursorPost, searchFeedConditionDto.getSortStrategy())
                 )
-                .limit(searchCommentConditionDto.getSize())
+                .limit(searchFeedConditionDto.getSize());
+    }
+
+//
+
+    @Override
+    public List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .where(
+                        post.isHidden.eq(false),
+                        keyWordSearch(searchFeedConditionDto.getSearchKeyword()),
+                        period(searchFeedConditionDto.getDateFrom(), searchFeedConditionDto.getDateTo())
+                )
+                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()), boardSort(SortStrategy.CHRONOLOGICAL))
                 .fetch();
-
-
-        if(me != null) {
-            for(CommentResponseDto commentResponseDto : content) {
-                if(commentLikeRepository.existsCommentLikeByUserAndCommentId(me, commentResponseDto.getCommentId())) {
-                    commentResponseDto.setIsLiked(true);
-                }
-            }
-        }
-
-        return content;
     }
 
-    private Predicate cursorPagination(Comment cursorComment) {
-        if(cursorComment == null) {
+    @Override
+    public List<FeedResultPostDto> searchFeedByHashtag(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .leftJoin(post.hashtags, hashtag)
+                .where(
+                        post.isHidden.eq(false),
+                        hashtagSearch(searchFeedConditionDto.getSearchHashtag()),
+                        period(searchFeedConditionDto.getDateFrom(), searchFeedConditionDto.getDateTo())
+                )
+                .orderBy(boardSort(searchFeedConditionDto.getSortStrategy()), boardSort(SortStrategy.CHRONOLOGICAL))
+                .fetch();
+    }
+
+    @Override
+    public List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .where(
+                        hiddenPostFilter(owner, me),
+                        anonymousPostFilter(owner, me),
+                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), owner, me)
+                )
+                .orderBy(boardSort(SortStrategy.CHRONOLOGICAL))
+                .fetch();
+    }
+
+    @Override
+    public List<FeedResultPostDto> searchUserPageByBookmark(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .leftJoin(post.bookmarkList, bookmark)
+                .where(
+                        hiddenPostFilter(owner, me),
+                        anonymousPostFilter(owner, me),
+                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), owner, me)
+                )
+                .orderBy(boardSort(SortStrategy.CHRONOLOGICAL))
+                .fetch();
+    }
+
+    @Override
+    public List<FeedResultPostDto> searchUserPageByPurchase(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .leftJoin(post.purchaseList, purchase)
+                .where(
+                        hiddenPostFilter(owner, me),
+                        anonymousPostFilter(owner, me),
+                        userPageFeedOption(searchFeedConditionDto.getUserPageFeedOption(), owner, me)
+                )
+                .orderBy(boardSort(SortStrategy.CHRONOLOGICAL))
+                .fetch();
+    }
+
+    private Predicate keyWordSearch(String searchString) {
+
+        if(searchString == null) {
+            return null;
+        } else {
+            return ExpressionUtils.or(post.title.contains(searchString), post.content.contains(searchString));
+        }
+    }
+
+    private Predicate hashtagSearch(String searchHashtag) {
+
+        if(searchHashtag == null) {
+            return null;
+        } else {
+            return hashtag.content.eq(searchHashtag);
+        }
+    }
+
+    private Predicate anonymousPostFilter(User owner, User me) {
+
+        if(owner == me) {
+            return null;
+        } else {
+            return post.isAnonymous.eq(false);
+        }
+    }
+
+    private Predicate hiddenPostFilter(User owner, User me) {
+
+        if(owner == me) {
+            return null;
+        } else {
+            return post.isHidden.eq(false);
+        }
+    }
+
+    private Predicate userPageFeedOption(UserPageFeedOption userPageFeedOption, User owner, User me) {
+
+        if(userPageFeedOption == null) {
             return null;
         }
-        return comment.id.gt(cursorComment.getId());
+
+        switch (userPageFeedOption) {
+            case BUY:
+                return purchase.user.eq(me);
+            case BOOKMARK:
+                return bookmark.user.eq(me);
+            case WRITE:
+            default:
+                return post.user.eq(owner);
+        }
     }
 
-    private Predicate target(CommentTargetType targetType, Long targetId) {
+    private Predicate soldOption(SoldOption soldOption) {
 
-        if(targetId == null || targetId == 0) {
+        switch (soldOption) {
+            case SOLD:
+                return post.isSold.eq(true);
+            case UNSOLD:
+                return post.isSold.eq(false);
+            case ALL:
+            default:
+                return null;
+        }
+
+    }
+
+    private Predicate period(LocalDateTime dateFrom, LocalDateTime dateTo) {
+        if(dateFrom == null || dateTo == null) {
+            return null;
+        } else {
+            return post.createdDate.between(dateFrom, dateTo);
+        }
+    }
+
+    private Predicate cursorPagination(Post cursorPost, SortStrategy sortStrategy) {
+
+        if(cursorPost == null || sortStrategy == null) {
             return null;
         }
 
-        switch (targetType) {
-            case POST:
-                return and(comment.post.id.eq(targetId), comment.parent.isNull());
-            case COMMENT:
-                return comment.parent.id.eq(targetId);
+        switch (sortStrategy) {
+            case LIKE:
+                return post.postLikeList.size().loe(cursorPost.getPostLikeList().size());
+            case VIEW:
+                return post.viewCount.loe(cursorPost.getViewCount());
+            case CHRONOLOGICAL:
+            default:
+                return post.id.lt(cursorPost.getId());
         }
-        return null;
     }
+
+    private Predicate sameLevelCursorFilter(Post cursorPost, SortStrategy sortStrategy) {
+
+        if(cursorPost == null || sortStrategy == null) {
+            return null;
+        }
+
+        switch (sortStrategy) {
+            case LIKE:
+                return ExpressionUtils.or(post.postLikeList.size().ne(cursorPost.getPostLikeList().size()), post.id.lt(cursorPost.getId()));
+            case VIEW:
+                return ExpressionUtils.or(post.viewCount.ne(cursorPost.getViewCount()), post.id.lt(cursorPost.getId()));
+            case CHRONOLOGICAL:
+            default:
+                return null;
+        }
+    }
+
+    private OrderSpecifier<?> boardSort(SortStrategy sortStrategy) {
+
+        if(sortStrategy == null){
+            return new OrderSpecifier<>(Order.DESC, post.id);
+        }
+
+        switch (sortStrategy){
+            case LIKE:
+                return new OrderSpecifier<>(Order.DESC, post.postLikeList.size());
+            case VIEW:
+                return new OrderSpecifier<>(Order.DESC, post.viewCount);
+            case CHRONOLOGICAL:
+                return new OrderSpecifier<>(Order.DESC, post.id);
+        }
+
+        return new OrderSpecifier<>(Order.DESC, post.id);
+
+    }
+
 }

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -37,55 +37,6 @@ public class FeedRepositoryTest {
 
     @Autowired EntityManager em;
 
-    @DisplayName("유저가 like한 게시글은, isLiked가 true로 반환된다.")
-    @Test
-    void feedIsLike() {
-
-        User user = new User();
-        userRepository.save(user);
-        Post post = new Post();
-        postRepository.save(post);
-        PostLike postLike = new PostLike(user, post);
-        postLikeRepository.save(postLike);
-
-        em.flush();
-
-        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
-                .builder()
-                .size(1L)
-                .soldOption(SoldOption.ALL)
-                .build();
-
-        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
-
-        assertTrue(result.get(0).getIsLiked());
-        assertEquals(1, result.get(0).getLikeCount());
-    }
-
-    @DisplayName("유저가 bookmark한 게시글은, isBookmarked가 true로 반환된다.")
-    @Test
-    void feedIsBookmarked() {
-
-        User user = new User();
-        userRepository.save(user);
-        Post post = new Post();
-        postRepository.save(post);
-        Bookmark bookmark = new Bookmark(user, post);
-        bookmarkRepository.save(bookmark);
-
-        em.flush();
-
-        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
-                .builder()
-                .size(1L)
-                .soldOption(SoldOption.ALL)
-                .build();
-
-        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
-
-        assertTrue(result.get(0).getIsBookmarked());
-    }
-
     @DisplayName("다른 사람이 숨긴 게시글은, 유저 페이지에 나타나지 않는다.")
     @Test
     void hideHiddenPostInOtherUserPage() {
@@ -326,7 +277,7 @@ public class FeedRepositoryTest {
                 .searchHashtag("해시태그")
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+        List<FeedResultPostDto> result = feedRepository.searchFeedByHashtag(searchFeedConditionDto, null, user);
         assertEquals(1, result.size());
         assertEquals(postWithHashtag.getId(), result.get(0).getPostId());
     }
@@ -370,7 +321,7 @@ public class FeedRepositoryTest {
                 .searchHashtag("해시태그")
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
+        List<FeedResultPostDto> result = feedRepository.searchFeedByHashtag(searchFeedConditionDto, null, user);
         assertEquals(1, result.size());
         assertEquals(postWithHashtag.getId(), result.get(0).getPostId());
     }

--- a/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedServiceRepositoryTest.java
@@ -349,7 +349,7 @@ public class FeedServiceRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, owner, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageByBookmark(searchFeedConditionDto, owner, owner, null);
 
         assertEquals(3, result.size());
     }
@@ -389,7 +389,7 @@ public class FeedServiceRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, owner, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageByPurchase(searchFeedConditionDto, owner, owner, null);
 
         assertEquals(3, result.size());
     }

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -1,15 +1,15 @@
 package com.dope.breaking.service;
 
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostLike;
+import com.dope.breaking.domain.user.Bookmark;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.exception.user.LoginRequireException;
 import com.dope.breaking.exception.user.NoPermissionException;
-import com.dope.breaking.repository.FeedRepository;
-import com.dope.breaking.repository.PostRepository;
-import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.repository.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,8 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
 
@@ -35,9 +34,12 @@ public class FeedServiceTest {
     private FeedRepository feedRepository;
     @Mock
     private UserRepository userRepository;
-
     @Mock
     private PostRepository postRepository;
+    @Mock
+    private BookmarkRepository bookmarkRepository;
+    @Mock
+    private PostLikeRepository postLikeRepository;
 
     @InjectMocks
     private SearchFeedService feedService;
@@ -249,4 +251,73 @@ public class FeedServiceTest {
         assertEquals("좋은 아침", searchFeedConditionDto.getSearchKeyword());
 
     }
+
+    @DisplayName("유저가 bookmark한 게시글은, isBookmarked가 true로 반환된다.")
+    @Test
+    void feedIsBookmarked() {
+
+        //given
+        User me = new User();
+        me.setRequestFields("URL", "URL", "owner", "01012345678", "email@naver.com", "Jinu", "msg", "username", Role.USER);
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(1L)
+                .soldOption(SoldOption.ALL)
+                .build();
+
+
+        when(userRepository.findByUsername(me.getUsername())).thenReturn(Optional.of(me));
+
+        List<FeedResultPostDto> dummy = new ArrayList<>();
+        FeedResultPostDto content = FeedResultPostDto.builder()
+                .isAnonymous(false)
+                .build();
+        dummy.add(content);
+        given(feedRepository.searchFeedBy(searchFeedConditionDto, null, me)).willReturn(dummy);
+        given(bookmarkRepository.existsByUserAndPostId(me, null)).willReturn(true);
+        given(postLikeRepository.existsByUserAndPostId(me, null)).willReturn(false);
+
+        //when
+        List<FeedResultPostDto> result = feedService.searchMainFeed(searchFeedConditionDto, me.getUsername(), null);
+
+        //then
+        assertTrue(result.get(0).getIsBookmarked());
+
+    }
+
+    @DisplayName("유저가 like한 게시글은, isLiked가 true로 반환된다.")
+    @Test
+    void feedIsLiked() {
+
+        //given
+        User me = new User();
+        me.setRequestFields("URL", "URL", "owner", "01012345678", "email@naver.com", "Jinu", "msg", "username", Role.USER);
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto
+                .builder()
+                .size(1L)
+                .soldOption(SoldOption.ALL)
+                .build();
+
+
+        when(userRepository.findByUsername(me.getUsername())).thenReturn(Optional.of(me));
+
+        List<FeedResultPostDto> dummy = new ArrayList<>();
+        FeedResultPostDto content = FeedResultPostDto.builder()
+                .isAnonymous(false)
+                .build();
+        dummy.add(content);
+        given(feedRepository.searchFeedBy(searchFeedConditionDto, null, me)).willReturn(dummy);
+        given(bookmarkRepository.existsByUserAndPostId(me, null)).willReturn(false);
+        given(postLikeRepository.existsByUserAndPostId(me, null)).willReturn(true);
+
+        //when
+        List<FeedResultPostDto> result = feedService.searchMainFeed(searchFeedConditionDto, me.getUsername(), null);
+
+        //then
+        assertTrue(result.get(0).getIsLiked());
+
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #245 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
dynamic join 을 하는 방법을 찾아서,
메인 피드, 유저페이지 피드, 게시글 검색 쿼리를 통합했습니다.

추가로 breaking mission 게시글도 해당 쿼리로 확장해서 구현 예정입니다 ~

그리고..
- 북마크 했는가
- 좋아요 했는가
해당 필드를 넣는 코드가 repository 계층에 있었는데, service 계층으로 옮겼습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
참고 ref
https://stackoverflow.com/questions/73017612/can-i-use-dynamic-join-in-querydsl