### PR TITLE
feat: implement breaking mission submission

### DIFF
--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -3,14 +3,16 @@ package com.dope.breaking.api;
 import com.dope.breaking.dto.mission.MissionRequestDto;
 import com.dope.breaking.service.MissionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
 import java.security.Principal;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,10 +23,14 @@ public class MissionAPI {
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/breaking-mission")
     public ResponseEntity createMission(Principal principal, @RequestBody @Valid MissionRequestDto missionRequestDto){
-
         missionService.createMission(missionRequestDto, principal.getName());
         return ResponseEntity.ok().build();
+    }
 
+    @PreAuthorize("isAuthenticated()")
+    @PostMapping(value = "/breaking-mission/{missionId}", consumes = {"multipart/form-data"})
+    public ResponseEntity<Map<String, Long>> submitPostForMission(Principal principal, @PathVariable Long missionId, @RequestPart(value = "mediaList", required = false) List<MultipartFile> files, @RequestPart(value = "data") String contentData) throws Exception {
+        return ResponseEntity.status(HttpStatus.OK).body(missionService.postSubmission(principal.getName(),contentData,files,missionId));
     }
 
 }

--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -123,6 +123,8 @@ public class Post extends BaseTimeEntity {
 
     public void updateIsSold (boolean isSold) { this.isSold = isSold; }
 
-    public void updateIsPurchasable (boolean isPurchasable ) { this.isPurchasable = isPurchasable; }
+    public void updateIsPurchasable (boolean isPurchasable) { this.isPurchasable = isPurchasable; }
+
+    public void updateMission(Mission mission) {this.mission = mission;}
 
 }

--- a/src/main/java/com/dope/breaking/domain/post/PostType.java
+++ b/src/main/java/com/dope/breaking/domain/post/PostType.java
@@ -8,7 +8,9 @@ import lombok.*;
 public enum PostType {
     EXCLUSIVE("EXCLUSIVE"),
     CHARGED("CHARGED"),
-    FREE("FREE");
+    FREE("FREE"),
+    MISSION("MISSION");
+
 
     private final String title;
 }

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     NOT_PURCHASABLE_POST("BSE460", "구매 제한이 된 포스트입니다."),
     SOLD_EXCLUSIVE_POST("BSE461", "이미 판매 된 단독제보입니다."),
 
+    NO_SUCH_BREAKING_MISSION("BSE480", "존재하지 않는 브레이킹미션입니다."),
     MISSION_ONLY_FOR_PRESS("BSE481", "브레이킹 미션은 언론사만 게시 가능합니다."),
 
 

--- a/src/main/java/com/dope/breaking/exception/mission/MissionOnlyForPressException.java
+++ b/src/main/java/com/dope/breaking/exception/mission/MissionOnlyForPressException.java
@@ -1,4 +1,4 @@
-package com.dope.breaking.exception.post;
+package com.dope.breaking.exception.mission;
 
 import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.ErrorCode;

--- a/src/main/java/com/dope/breaking/exception/mission/NoSuchBreakingMissionException.java
+++ b/src/main/java/com/dope/breaking/exception/mission/NoSuchBreakingMissionException.java
@@ -1,0 +1,13 @@
+package com.dope.breaking.exception.mission;
+
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public class NoSuchBreakingMissionException extends BreakingException {
+
+    public NoSuchBreakingMissionException() {super(ErrorCode.NO_SUCH_BREAKING_MISSION, HttpStatus.BAD_REQUEST);}
+
+}
+
+

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -66,7 +66,7 @@ public class PostService {
 
     @Transactional
     public Long create(String username, String contentData, List<MultipartFile> files) throws Exception {
-        User user = userRepository.findByUsername(username).get();
+        User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
 
         PostRequestDto postRequestDto = transferPostRequestToObject(contentData);
 
@@ -328,6 +328,8 @@ public class PostService {
             postType = PostType.CHARGED;
         } else if (PostType.FREE.getTitle().equalsIgnoreCase(requestPostType)) {
             postType = PostType.FREE;
+        } else if (PostType.MISSION.getTitle().equalsIgnoreCase(requestPostType)) {
+            postType = PostType.MISSION;
         }
         return postType;
     }

--- a/src/test/java/com/dope/breaking/api/MissionAPITest.java
+++ b/src/test/java/com/dope/breaking/api/MissionAPITest.java
@@ -1,10 +1,13 @@
 package com.dope.breaking.api;
 
+import com.dope.breaking.domain.post.Mission;
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.mission.MissionRequestDto;
 import com.dope.breaking.dto.post.LocationDto;
 import com.dope.breaking.repository.MissionRepository;
+import com.dope.breaking.repository.PostRepository;
 import com.dope.breaking.repository.UserRepository;
 import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -18,11 +21,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockPart;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.UUID;
@@ -47,6 +58,9 @@ class MissionAPITest {
 
     @Autowired
     private MissionRepository missionRepository;
+
+    @Autowired
+    private PostRepository postRepository;
 
     @Autowired
     private ObjectMapper objectMapper;
@@ -163,6 +177,106 @@ class MissionAPITest {
         this.mockMvc.perform(post("/breaking-mission")
                         .content(requestJson)
                         .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest()); //Then
+
+    }
+
+    @DisplayName("missionId가 유효하지 않은 경우, 예외가 발생한다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void submitPostForMission() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.USER);
+        userRepository.save(user);
+
+        User press = new User();
+        userRepository.save(press);
+
+        Mission mission = new Mission(user,"title","content",null,null,null);
+        missionRepository.save(mission);
+
+        MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"mission\"," +
+                "\"eventDate\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"address\" : \"address\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345," +
+                "\"region_1depth_name\" : \"region_1depth_name\"," +
+                "\"region_2depth_name\" : \"region_2depth_name\" " +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        //When
+        this.mockMvc.perform(MockMvcRequestBuilders.multipart("/breaking-mission/{missionId}", mission.getId())
+                        .file(multipartFile1)
+                        .part(new MockPart("data", json.getBytes(StandardCharsets.UTF_8)))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());  //Then
+
+        //Then
+        Assertions.assertEquals(PostType.MISSION,postRepository.findAll().get(0).getPostType());
+        Assertions.assertEquals(mission,postRepository.findAll().get(0).getMission());
+
+    }
+
+    @DisplayName("유저네임이 일치할 때 미션을 수행할 경우, 제보가 문제 없이 생성된다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void submitPostForMissionWithInvalidMissionId() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.USER);
+        userRepository.save(user);
+
+        User press = new User();
+        userRepository.save(press);
+
+        Mission mission = new Mission(user,"title","content",null,null,null);
+        missionRepository.save(mission);
+
+        MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"mission\"," +
+                "\"eventDate\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"address\" : \"address\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345," +
+                "\"region_1depth_name\" : \"region_1depth_name\"," +
+                "\"region_2depth_name\" : \"region_2depth_name\" " +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        //When
+        this.mockMvc.perform(MockMvcRequestBuilders.multipart("/breaking-mission/{missionId}", 100L)
+                        .file(multipartFile1)
+                        .part(new MockPart("data", json.getBytes(StandardCharsets.UTF_8)))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isBadRequest()); //Then
 
     }

--- a/src/test/java/com/dope/breaking/service/MissionServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/MissionServiceTest.java
@@ -5,7 +5,7 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.mission.MissionRequestDto;
 import com.dope.breaking.dto.post.LocationDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
-import com.dope.breaking.exception.post.MissionOnlyForPressException;
+import com.dope.breaking.exception.mission.MissionOnlyForPressException;
 import com.dope.breaking.repository.MissionRepository;
 import com.dope.breaking.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -20,7 +20,6 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #247 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 미션을 위한 제보 제출 기능을 구현했습니다.
  - postType에 "mission" 을 추가했습니다. 
  - 기존의 postService.create 매서드를 활용했습니다. 프론트가 제보 제출 기능을 호출할 경우, postType는 무조건 "mission" 으로 넘겨서 백엔드로 넘겨줘야 합니다.
  - Post의 mission 필드를 추가해줍니다. 

- "MissionOnlyForPressException"을 "post"패키지에서 "mission"패키지로 옮겼습니다. @Martin0o0 리베이스 시 충돌 문제를 주의 해주시길 바랍니다.

- 해당하는 테스트코드를 작성했습니다.  

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

- 제보 숨기기/숨기기 취소 기능을 개발하겠습니다. 