### PR TITLE
feat: implement follower count in user search

### DIFF
--- a/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
@@ -22,20 +22,20 @@ public class SearchUserResponseDto {
 
     Role role;
 
-    int followingCount;
+    int followerCount;
 
     Boolean isFollowing;
 
     @Builder
     @QueryProjection
-    public SearchUserResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followingCount, Boolean isFollowing) {
+    public SearchUserResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followerCount, Boolean isFollowing) {
         this.userId = userId;
         this.profileImgURL = profileImgURL;
         this.nickname = nickname;
         this.email = email;
         this.statusMsg = statusMsg;
         this.role = role;
-        this.followingCount = followingCount;
+        this.followerCount = followerCount;
         this.isFollowing = isFollowing;
     }
 }

--- a/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/SearchUserResponseDto.java
@@ -22,17 +22,20 @@ public class SearchUserResponseDto {
 
     Role role;
 
+    int followingCount;
+
     Boolean isFollowing;
 
     @Builder
     @QueryProjection
-    public SearchUserResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, Boolean isFollowing) {
+    public SearchUserResponseDto(Long userId, String profileImgURL, String nickname, String email, String statusMsg, Role role, int followingCount, Boolean isFollowing) {
         this.userId = userId;
         this.profileImgURL = profileImgURL;
         this.nickname = nickname;
         this.email = email;
         this.statusMsg = statusMsg;
         this.role = role;
+        this.followingCount = followingCount;
         this.isFollowing = isFollowing;
     }
 }

--- a/src/main/java/com/dope/breaking/repository/FollowRepository.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepository.java
@@ -19,8 +19,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     void deleteByFollowedAndFollowing(User followed, User following);
 
-    List<Follow> findAllByFollowing(User following);
-
-    List<Follow> findAllByFollowed(User followed);
-
+    boolean existsFollowsByFollowedIdAndFollowingId(Long followed, Long following);
 }

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
@@ -36,25 +36,15 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.statusMsg,
                         user.role,
                         user.followerList.size(),
-                        isFollowing(me)
+                        Expressions.asBoolean(false)
                 ))
                 .from(user)
-                .leftJoin(user.followerList, follow)
                 .where(
                         cursorPagination(cursorUser),
                         user.nickname.contains(searchKeyword)
                 )
                 .limit(size)
                 .fetch();
-    }
-
-    private Predicate isFollowing(User me) {
-
-        if(me == null) {
-            return Expressions.asBoolean(false);
-        } else {
-            return follow.following.eq(me);
-        }
     }
 
     private Predicate cursorPagination(User cursorUser) {

--- a/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/UserRepositoryCustomImpl.java
@@ -35,6 +35,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
                         user.email,
                         user.statusMsg,
                         user.role,
+                        user.followerList.size(),
                         isFollowing(me)
                 ))
                 .from(user)

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -89,29 +89,6 @@ class UserRepositoryTest {
 
     }
 
-    @DisplayName("유저 검색 시, 팔로잉 중인 유저는 isFolowing이 true로 반환된다.")
-    @Test
-    void isFollowingSearchedUser() {
-
-        User me = new User();
-        me.setRequestFields("URL", "anyURL", "테스트닉네임1", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
-        userRepository.save(me);
-
-        User followingUser = new User();
-        followingUser.setRequestFields("URL", "anyURL", "테스트닉네임2", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
-        userRepository.save(followingUser);
-
-        Follow follow = new Follow(me, followingUser);
-        followRepository.save(follow);
-
-        em.flush();
-
-        List<SearchUserResponseDto> result = userRepository.searchUserBy(me, "테스트닉네임2", null, 2L);
-
-        assertTrue(result.get(0).getIsFollowing());
-
-    }
-
     @DisplayName("유저 검색 시, 팔로워중인 사람의 수가 표시된다.")
     @Test
     void SearchedUserFollowerCount() {
@@ -130,7 +107,7 @@ class UserRepositoryTest {
 
         List<SearchUserResponseDto> result = userRepository.searchUserBy(null, "닉네임", null, 5L);
 
-        assertEquals(5, result.get(0).getFollowingCount());
+        assertEquals(5, result.get(0).getFollowerCount());
 
     }
 

--- a/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/UserRepositoryTest.java
@@ -112,4 +112,26 @@ class UserRepositoryTest {
 
     }
 
+    @DisplayName("유저 검색 시, 팔로워중인 사람의 수가 표시된다.")
+    @Test
+    void SearchedUserFollowerCount() {
+
+        User user = new User();
+        user.setRequestFields("URL", "anyURL", "닉네임", "01012345678", "abc.google.com", "realname", "msg", "username", Role.USER);
+        userRepository.save(user);
+
+        followRepository.save(new Follow(user, user));
+        followRepository.save(new Follow(user, user));
+        followRepository.save(new Follow(user, user));
+        followRepository.save(new Follow(user, user));
+        followRepository.save(new Follow(user, user));
+
+        em.flush();
+
+        List<SearchUserResponseDto> result = userRepository.searchUserBy(null, "닉네임", null, 5L);
+
+        assertEquals(5, result.get(0).getFollowingCount());
+
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #255 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 유저 검색 결과에 followerCount를 추가했습니다.
- isfollowing 필드 값 입력을 service 계층으로 꺼냈습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/185051475-870f5ca9-a005-4ac6-80b4-62386902cd88.png)

