### PR TITLE
fix: dynamic join query bug by outer join

### DIFF
--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -11,12 +11,6 @@ public interface FeedRepositoryCustom {
 
     List<FeedResultPostDto> searchFeedBy(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
 
-    List<FeedResultPostDto> searchFeedByHashtag(SearchFeedConditionDto searchFeedConditionDto, Post cursorPost, User me);
-
-    List<FeedResultPostDto> searchUserPageByBookmark(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
-
-    List<FeedResultPostDto> searchUserPageByPurchase(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
-
     List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
 
 }

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -52,7 +52,7 @@ public class SearchFeedService {
         List<FeedResultPostDto> result;
 
         if(searchFeedConditionDto.getSearchHashtag() != null) {
-            result = feedRepository.searchFeedByHashtag(searchFeedConditionDto, cursorPost, me);
+            result = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
         } else {
             result = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
         }
@@ -99,9 +99,9 @@ public class SearchFeedService {
 
         switch (searchFeedConditionDto.getUserPageFeedOption()) {
             case BOOKMARK:
-                result = feedRepository.searchUserPageByBookmark(searchFeedConditionDto, owner, me, cursorPost);
+                result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, me, cursorPost);
             case BUY:
-                result = feedRepository.searchUserPageByPurchase(searchFeedConditionDto, owner, me, cursorPost);
+                result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, me, cursorPost);
             case WRITE:
             default:
                 result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, me, cursorPost);

--- a/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FeedRepositoryTest.java
@@ -46,6 +46,7 @@ public class FeedRepositoryTest {
         Post post = Post.builder()
                 .isHidden(true)
                 .build();
+        post.setUser(owner);
         postRepository.save(post);
         Bookmark bookmark = new Bookmark(owner, post);
         bookmarkRepository.save(bookmark);
@@ -67,13 +68,14 @@ public class FeedRepositoryTest {
     @Test
     void displayHiddenPostInMyPage() {
 
-        User user = new User();
-        userRepository.save(user);
+        User owner = new User();
+        userRepository.save(owner);
         Post post = Post.builder()
                 .isHidden(true)
                 .build();
+        post.setUser(owner);
         postRepository.save(post);
-        Bookmark bookmark = new Bookmark(user, post);
+        Bookmark bookmark = new Bookmark(owner, post);
         bookmarkRepository.save(bookmark);
 
         em.flush();
@@ -84,7 +86,7 @@ public class FeedRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, user, user, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, owner, owner, null);
 
         assertEquals(result.get(0).getPostId(), post.getId());
     }
@@ -93,11 +95,15 @@ public class FeedRepositoryTest {
     @Test
     void hideAnonymousPostInOtherUsersPage() {
 
+        User me = new User();
+        userRepository.save(me);
+
         User user = new User();
         userRepository.save(user);
         Post post = Post.builder()
                 .isAnonymous(true)
                 .build();
+        post.setUser(user);
         postRepository.save(post);
 
         em.flush();
@@ -108,7 +114,7 @@ public class FeedRepositoryTest {
                 .soldOption(SoldOption.ALL)
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, user, null, null);
+        List<FeedResultPostDto> result = feedRepository.searchUserPageBy(searchFeedConditionDto, user, me, null);
 
         assertEquals(0, result.size());
     }
@@ -122,6 +128,7 @@ public class FeedRepositoryTest {
         Post post = Post.builder()
                 .isAnonymous(true)
                 .build();
+        post.setUser(user);
         postRepository.save(post);
 
         em.flush();
@@ -277,7 +284,7 @@ public class FeedRepositoryTest {
                 .searchHashtag("해시태그")
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchFeedByHashtag(searchFeedConditionDto, null, user);
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
         assertEquals(1, result.size());
         assertEquals(postWithHashtag.getId(), result.get(0).getPostId());
     }
@@ -321,7 +328,7 @@ public class FeedRepositoryTest {
                 .searchHashtag("해시태그")
                 .build();
 
-        List<FeedResultPostDto> result = feedRepository.searchFeedByHashtag(searchFeedConditionDto, null, user);
+        List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, null, user);
         assertEquals(1, result.size());
         assertEquals(postWithHashtag.getId(), result.get(0).getPostId());
     }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #259 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
엔티티 관계에서 join을 사용하다 보니, 혼동이 있어서 버그가 발생했습니다.


## 에러 발생 예시
![image](https://user-images.githubusercontent.com/76773202/185284847-a93dd825-cf7c-49ff-8fe7-f6f7ff879bd4.png)

포스트과 좋아요의 관계는,
포스트 : 좋아요 = 1 : N 입니다.

그런데 여기서 피드를 조회하는 경우를 생각해봅시다.

피드에서 좋아요에 대한 정보를 나타내기 위해서 좋아요 테이블을 join 하면 어떻게 될까요?
```
select
from 포스트
left join 좋아요
```
![image](https://user-images.githubusercontent.com/76773202/185284927-7a75dc07-39ee-48d4-84a8-8211974344cf.png)

이렇게 여러개의 좋아요를 받은 포스트가 여러개가 조회됩니다.

## 해결방법
1. 쿼리를 분리한다 (해당 PR 코드에 적용)
2. select from 좋아요 left join 좋아요 //예시가 좋지는 않음.. ㅋㅋ 1:n 관계에서, n이 기준 테이블이 되어야 함.
