### PR TITLE
feat: breaking mission detail lookup

### DIFF
--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.api;
 
 import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.dto.mission.MissionResponseDto;
+import com.dope.breaking.dto.post.DetailPostResponseDto;
 import com.dope.breaking.service.MissionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,6 +33,17 @@ public class MissionAPI {
     @PostMapping(value = "/breaking-mission/{missionId}", consumes = {"multipart/form-data"})
     public ResponseEntity<Map<String, Long>> submitPostForMission(Principal principal, @PathVariable Long missionId, @RequestPart(value = "mediaList", required = false) List<MultipartFile> files, @RequestPart(value = "data") String contentData) throws Exception {
         return ResponseEntity.status(HttpStatus.OK).body(missionService.postSubmission(principal.getName(),contentData,files,missionId));
+    }
+
+
+
+    @GetMapping("/breaking-mission/{missionId}")
+    public ResponseEntity<MissionResponseDto> readMission(@PathVariable("missionId") long missionId, Principal principal){
+        String crntUsername = null;
+        if(principal != null){
+            crntUsername = principal.getName();
+        }
+        return missionService.readMission(missionId, crntUsername);
     }
 
 }

--- a/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
@@ -1,0 +1,46 @@
+package com.dope.breaking.dto.mission;
+
+import com.dope.breaking.domain.post.Mission;
+import com.dope.breaking.dto.post.LocationDto;
+import com.dope.breaking.dto.post.WriterDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+@Setter
+public class MissionResponseDto {
+
+    @JsonProperty(value = "isMyMission")
+    Boolean isMyMission;
+
+    String title;
+
+    String content;
+
+    LocalDateTime startTime;
+
+    LocalDateTime endTime;
+
+
+    LocationDto locationDto;
+
+    WriterDto user;
+
+    @Builder
+    public MissionResponseDto(String title, String content, LocalDateTime startTime, LocalDateTime endTime, Boolean isMyMission, LocationDto locationDto, WriterDto writerDto){
+        this.isMyMission = isMyMission;
+        this.title = title;
+        this.content = content;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.locationDto = locationDto;
+        this.user = writerDto;
+    }
+
+}

--- a/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
@@ -28,7 +28,7 @@ public class MissionResponseDto {
     LocalDateTime endTime;
 
 
-    LocationDto locationDto;
+    LocationDto location;
 
     WriterDto user;
 
@@ -39,7 +39,7 @@ public class MissionResponseDto {
         this.content = content;
         this.startTime = startTime;
         this.endTime = endTime;
-        this.locationDto = locationDto;
+        this.location = locationDto;
         this.user = writerDto;
     }
 

--- a/src/main/java/com/dope/breaking/service/MissionService.java
+++ b/src/main/java/com/dope/breaking/service/MissionService.java
@@ -5,6 +5,11 @@ import com.dope.breaking.domain.post.Mission;
 import com.dope.breaking.domain.user.Role;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.mission.MissionRequestDto;
+import com.dope.breaking.dto.mission.MissionResponseDto;
+import com.dope.breaking.dto.post.LocationDto;
+import com.dope.breaking.dto.post.WriterDto;
+import com.dope.breaking.exception.BreakingException;
+import com.dope.breaking.exception.ErrorCode;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.mission.MissionOnlyForPressException;
 import com.dope.breaking.exception.mission.NoSuchBreakingMissionException;
@@ -71,4 +76,44 @@ public class MissionService {
 
     }
 
+    public ResponseEntity<MissionResponseDto> readMission(long missionId, String crntUsername){
+
+        //예외처리 수정 필요
+        Mission mission = missionRepository.findById(missionId).orElseThrow(() -> new BreakingException(ErrorCode.INTERNAL_SERVER_ERROR, HttpStatus.BAD_REQUEST));
+
+
+        boolean isMyMission = false;
+        if(crntUsername != null){
+            User user = userRepository.findByUsername(crntUsername).get();
+            isMyMission = user == mission.getUser(); //JPA의 동일성 보장
+        }
+
+        LocationDto locationDto = LocationDto.builder()
+                .address(mission.getLocation().getAddress())
+                .latitude(mission.getLocation().getLatitude())
+                .longitude(mission.getLocation().getLongitude())
+                .region_1depth_name(mission.getLocation().getRegion_1depth_name())
+                .region_2depth_name(mission.getLocation().getRegion_2depth_name()).build();
+
+
+        User missionWriter = mission.getUser();
+        WriterDto writerDto = WriterDto.builder()
+                .userId(missionWriter.getId())
+                .profileImgURL(missionWriter.getOriginalProfileImgURL())
+                .nickname(missionWriter.getNickname()).build();
+
+
+        MissionResponseDto missionResponseDto = MissionResponseDto.builder()
+                .isMyMission(isMyMission)
+                .title(mission.getTitle())
+                .content(mission.getContent())
+                .startTime(mission.getStartTime())
+                .endTime(mission.getEndTime())
+                .locationDto(locationDto)
+                .writerDto(writerDto)
+                .build();
+
+        return new ResponseEntity<MissionResponseDto>(missionResponseDto, HttpStatus.OK);
+
+    }
 }

--- a/src/main/java/com/dope/breaking/service/MissionService.java
+++ b/src/main/java/com/dope/breaking/service/MissionService.java
@@ -79,7 +79,7 @@ public class MissionService {
     public ResponseEntity<MissionResponseDto> readMission(long missionId, String crntUsername){
 
         //예외처리 수정 필요
-        Mission mission = missionRepository.findById(missionId).orElseThrow(() -> new BreakingException(ErrorCode.INTERNAL_SERVER_ERROR, HttpStatus.BAD_REQUEST));
+        Mission mission = missionRepository.findById(missionId).orElseThrow(() -> new NoSuchBreakingMissionException());
 
 
         boolean isMyMission = false;

--- a/src/test/java/com/dope/breaking/api/MissionAPITest.java
+++ b/src/test/java/com/dope/breaking/api/MissionAPITest.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.api;
 
+import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Mission;
 import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.Role;
@@ -279,6 +280,51 @@ class MissionAPITest {
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isBadRequest()); //Then
 
+    }
+
+    @DisplayName("로그인 없이 브레이킹 미션을 조회 시, 정상적으로 처리된다.")
+    @Transactional
+    @Test
+    void readMissionWithAnonymous() throws Exception {
+
+        //Given
+        User press = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.PRESS);
+        userRepository.save(press);
+
+        Location location = new Location("full address",10.0,10.0,"depth1","depth2");
+
+        Mission mission = new Mission(press,"title","content",null,null,location);
+        long missionId = missionRepository.save(mission).getId();
+
+
+        //When
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/breaking-mission/" + missionId)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk()); //Then
+    }
+
+    @DisplayName("언론사가 작성한 브레이킹 미션을 직접 조회 시, 정상적으로 처리된다.")
+    @Transactional
+    @Test
+    void readMissionWithWriterOfPress() throws Exception {
+
+        //Given
+        User press = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.PRESS);
+        userRepository.save(press);
+
+
+        Location location = new Location("full address",10.0,10.0,"depth1","depth2");
+
+        Mission mission = new Mission(press,"title","content",null,null,location);
+        long missionId = missionRepository.save(mission).getId();
+
+
+        //When
+        this.mockMvc.perform(MockMvcRequestBuilders.get("/breaking-mission/" + missionId)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk()); //Then
     }
 
 }

--- a/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
@@ -17,26 +17,56 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class MissionRepositoryTest {
 
-    @Autowired MissionRepository missionRepository;
-    @Autowired UserRepository userRepository;
+    @Autowired
+    MissionRepository missionRepository;
+    @Autowired
+    UserRepository userRepository;
 
     @DisplayName("브레이킹 미션을 생성할 시, 미션이 정상적으로 저장된다.")
     @Test
-    void createMission(){
+    void createMission() {
 
         //Given
         User user = new User();
         userRepository.save(user);
 
         Location location = new Location("full address", 10.0, 10.0, "depth1", "depth2");
-        Mission mission = new Mission(user,"title","content",null,null,location);
+        Mission mission = new Mission(user, "title", "content", null, null, location);
 
         //When
         Long missionId = missionRepository.save(mission).getId();
 
         //Then
         Assertions.assertEquals(1, missionRepository.findAll().size());
-        Assertions.assertEquals(user,missionRepository.findById(missionId).get().getUser());
+        Assertions.assertEquals(user, missionRepository.findById(missionId).get().getUser());
+
+    }
+
+    @DisplayName("브레이킹 미션을 조회 시, 미션 상제 정보가 반횐된다.")
+    @Test
+    void readMission() {
+
+        //Given
+        User user = new User();
+        userRepository.save(user);
+
+        Location location = new Location("full address", 10.0, 10.0, "depth1", "depth2");
+        Mission mission = new Mission(user, "title", "content", null, null, location);
+        Long missionId = missionRepository.save(mission).getId();
+
+        //When
+        Mission mission1 = missionRepository.findById(missionId).get();
+
+
+        //Then
+        Assertions.assertEquals("title", mission1.getTitle());
+        Assertions.assertEquals("content", mission1.getContent());
+
+        Assertions.assertEquals(null, mission1.getStartTime());
+
+        Assertions.assertEquals(null, mission1.getEndTime());
+
+        Assertions.assertEquals(user, mission1.getUser());
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #248 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 브레이킹 미션 상세 조회 기능을 구현하였습니다. 로직은 기존의 Post와 많이 비슷합니다.

2. isMyMission필드를 통해 자신이 게시한 미션인지 확인 할 수 있습니다.3. 

3. Mockito를 통해 테스트 코드를 구현하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="708" alt="스크린샷 2022-08-18 오후 1 40 20" src="https://user-images.githubusercontent.com/62254434/185295256-78fe28b0-74fd-4082-8893-7cc3e19d4167.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
mockito가 상당히 어렵더군요... 이것 좀 공부하느라 service단의 테스트 코드 작성에서 좀 많이 걸렸습니다. 하지만, 확실히 구현하고 나니, 성능도 빠르고 여러모로 독립적이니 훨씬 더 테스트 코드에 가깝다는 생각이 드네요! 

노가다 교내 근로하느라 좀 많이 지체된것 같은데 짬짬이 시간내서 코딩하면서 PR 날립니다. 다음으로 워터마크 기능을 구현하도록 하겠습니다.