### PR TITLE
feat: purchase mission post

### DIFF
--- a/src/main/java/com/dope/breaking/service/PurchaseService.java
+++ b/src/main/java/com/dope/breaking/service/PurchaseService.java
@@ -48,13 +48,16 @@ public class PurchaseService {
 
             Purchase purchase = new Purchase(buyer, post, post.getPrice());
             purchaseRepository.save(purchase);
-            post.updateIsSold(true);
+
+            if(!post.isSold()) {
+                post.updateIsSold(true);
+            }
 
             transactionService.purchasePostTransaction(buyer, seller, purchase);
 
         }
 
-        else if (post.getPostType() ==PostType.CHARGED) {
+        else if (post.getPostType() == PostType.CHARGED) {
 
             if (buyer.getBalance() < post.getPrice()) {
                 throw new NotEnoughBalanceException();
@@ -64,11 +67,36 @@ public class PurchaseService {
             Purchase purchase = new Purchase(buyer, post, post.getPrice());
             purchaseRepository.save(purchase);
 
-            post.updateIsSold(true);
+            if(!post.isSold()) {
+                post.updateIsSold(true);
+            }
 
             transactionService.purchasePostTransaction(buyer, seller, purchase);
 
         }
+
+        else if (post.getPostType() == PostType.MISSION) {
+
+            if (post.getMission().getUser() != buyer) {
+                throw new NoPermissionException();
+            }
+
+            if (buyer.getBalance() < post.getPrice()) {
+                throw new NotEnoughBalanceException();
+            }
+
+            moneyTransfer (buyer, seller, post.getPrice());
+            Purchase purchase = new Purchase(buyer, post, post.getPrice());
+            purchaseRepository.save(purchase);
+
+            if(!post.isSold()) {
+                post.updateIsSold(true);
+            }
+
+            transactionService.purchasePostTransaction(buyer, seller, purchase);
+
+        }
+
         else if (post.getPostType() == PostType.EXCLUSIVE) {
 
             if (post.isSold()) {


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #253 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 브레이킹 미션에 제출 된 제보 구매 기능을 구현했습니다.
    - 미션에 제출 된 제보는 미션을 게시한 언론사만 구매할 수 있습니다. 다른 사용자가 구매할 경우 예외가 발생합니다. 
 - 이에 맞는 테스트 코드를 추가했습니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 미션 데드라인 종료 후 postType 변화 기능을 구현합니다.
- 팔로우/팔로워 페이지네이션 기능을 구현합니다. 
