### PR TITLE
fix: fix follow list error when cursor id is zero

### DIFF
--- a/src/main/java/com/dope/breaking/api/RelationshipAPI.java
+++ b/src/main/java/com/dope/breaking/api/RelationshipAPI.java
@@ -40,7 +40,7 @@ public class RelationshipAPI {
     }
 
     @GetMapping("/follow/following/{userId}")
-    public ResponseEntity<List<ForListInfoResponseDto>>followingUserList (
+    public ResponseEntity<List<ForListInfoResponseDto>> followingUserList (
             Principal principal,
             @PathVariable Long userId,
             @RequestParam(value = "cursor") Long cursorId,
@@ -51,7 +51,7 @@ public class RelationshipAPI {
     }
 
     @GetMapping("/follow/follower/{userId}")
-    public ResponseEntity<List<ForListInfoResponseDto>>followerUserList (
+    public ResponseEntity<List<ForListInfoResponseDto>> followerUserList (
             Principal principal,
             @PathVariable Long userId,
             @RequestParam(value = "cursor") Long cursorId,

--- a/src/main/java/com/dope/breaking/repository/FollowRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepositoryCustomImpl.java
@@ -90,7 +90,7 @@ public class FollowRepositoryCustomImpl implements FollowRepositoryCustom{
     }
 
     private Predicate cursorPagination(Long cursorId) {
-        if(cursorId == null || cursorId == 0) {
+        if(cursorId == null || cursorId == 0L) {
             return null;
         }
         return follow.id.gt(cursorId);

--- a/src/main/java/com/dope/breaking/service/FollowService.java
+++ b/src/main/java/com/dope/breaking/service/FollowService.java
@@ -70,15 +70,9 @@ public class FollowService {
         }
 
         if(followTargetType == FollowTargetType.FOLLOWING) {
-            if(followRepository.getById(cursorId).getFollowing()!=selectedUser){
-                throw new InvalidCursorException();
-            }
             return followRepository.followingList(me, selectedUser, cursorId, size);
         }
         else if(followTargetType == FollowTargetType.FOLLOWED) {
-            if(followRepository.getById(cursorId).getFollowed()!=selectedUser){
-                throw new InvalidCursorException();
-            }
             return followRepository.followerList(me, selectedUser, cursorId, size);
         }
 

--- a/src/test/java/com/dope/breaking/api/RelationshipAPITest.java
+++ b/src/test/java/com/dope/breaking/api/RelationshipAPITest.java
@@ -133,5 +133,22 @@ class RelationshipAPITest {
 
     }
 
+    @DisplayName("cursorId가 0인 경우, 팔로워/팔로잉 조회가 정상적으로 작동한다.")
+    @Test
+    void emptyFollowerList() throws Exception {
+
+        //Given
+        User user = new User("newUsername", "password", Role.USER);
+        userRepository.save(user);
+
+        //When
+        this.mockMvc.perform(get("/follow/follower/{userId}?cursor=0&size=10",user.getId()))
+                .andExpect(status().isOk());//Then
+
+        //When
+        this.mockMvc.perform(get("/follow/following/{userId}?cursor=0&size=10",user.getId()))
+                .andExpect(status().isOk());//Then
+
+    }
 
 }

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -312,13 +312,30 @@ class FollowRepositoryTest {
         followRepository.save(follow4);
 
         //When
-        List<ForListInfoResponseDto> followingList = followRepository.followerList(hero, hero,0L,10);
+        List<ForListInfoResponseDto> followerList = followRepository.followerList(hero, hero,0L,10);
 
         //Then
-        Assertions.assertEquals(3, followingList.size());
-        Assertions.assertTrue(followingList.get(0).isFollowing());
-        Assertions.assertTrue(followingList.get(1).isFollowing());
-        Assertions.assertFalse(followingList.get(2).isFollowing());
+        Assertions.assertEquals(3, followerList.size());
+        Assertions.assertTrue(followerList.get(0).isFollowing());
+        Assertions.assertTrue(followerList.get(1).isFollowing());
+        Assertions.assertFalse(followerList.get(2).isFollowing());
+
+    }
+
+    @DisplayName("아무도 팔로우 하지 않는 유저의 팔로잉 리스트를 조회할 경우, 팔로잉 여부가 정확히 반환된다.")
+    @Test
+    void readEmptyFollowingList(){
+
+        //Given
+        User user = new User();
+        userRepository.save(user);
+        User hero = userRepository.findByNickname("hero").get();
+
+        //when
+        List<ForListInfoResponseDto> followingList = followRepository.followingList(hero, user,0L,10);
+
+        //Then
+        Assertions.assertEquals(0,followingList.size());
 
     }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #269 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 팔로워/팔로잉 리스트 조회시 cursorId가 0일 때 에러가 터지는 문제를 해결했습니다.
   - 문제는 예외 처리시 cursorId 0을 가지고 getById를 함으로 발생했습니다. 이를 수정했습니다.
   - 그에 맞게 테스트 코드를 수정했습니다.

- 혹시 몰라 그 외의 페이지네이션 기능 역시 확인했습니다. 문제가 없었음을 확인했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
- 브레이킹 미션 종료 후 postType 변경 기능을 추가하겠습니다.