### PR TITLE
feat: implement post feed for breaking mission

### DIFF
--- a/src/main/java/com/dope/breaking/api/FeedAPI.java
+++ b/src/main/java/com/dope/breaking/api/FeedAPI.java
@@ -1,8 +1,8 @@
 package com.dope.breaking.api;
 
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
-import com.dope.breaking.dto.user.ProfileInformationResponseDto;
 import com.dope.breaking.dto.user.SearchUserResponseDto;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SearchFeedService;
@@ -36,6 +36,7 @@ public class FeedAPI {
             @RequestParam(value="search", required = false) String searchKeyword,
             @RequestParam(value="hashtag", required = false) String hashtag,
             @RequestParam(value="sort", required = false) String sortStrategy,
+            @RequestParam(value="post-type", required = false) String postType,
             @RequestParam(value="sold-option", required = false, defaultValue = "ALL") String soldOption,
             @RequestParam(value="date-from", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateFrom,
             @RequestParam(value="date-to", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime dateTo,
@@ -48,6 +49,7 @@ public class FeedAPI {
                 .size(size)
                 .sortStrategy(SortStrategy.findMatchedEnum(sortStrategy))
                 .soldOption(SoldOption.findMatchedEnum(soldOption))
+                .postType(PostType.findMatchedEnum(postType))
                 .dateFrom(dateFrom)
                 .dateFrom(dateFrom)
                 .dateTo(dateTo)
@@ -60,7 +62,6 @@ public class FeedAPI {
         }
 
         return ResponseEntity.ok().body(searchFeedService.searchMainFeed(searchFeedConditionDto, username, cursorId));
-
     }
 
     @GetMapping("/feed/user/{ownerId}/{userFeedPostOption}")

--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -1,6 +1,5 @@
 package com.dope.breaking.api;
 
-import com.dope.breaking.dto.comment.CommentResponseDto;
 import com.dope.breaking.dto.mission.MissionFeedResponseDto;
 import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.dto.mission.MissionRequestDto;
@@ -9,6 +8,7 @@ import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.service.MissionService;
 import com.dope.breaking.service.SearchFeedService;
+import com.dope.breaking.service.SortStrategy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
-import javax.websocket.server.PathParam;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -66,15 +65,16 @@ public class MissionAPI {
     }
 
     @GetMapping("/breaking-mission/{missionId}/feed")
-    public ResponseEntity<List<FeedResultPostDto>> searchFeed(
+    public ResponseEntity<List<FeedResultPostDto>> searchMissionPostFeed(
             Principal principal,
-            @PathParam(value="missionId") Long missionId,
-            @RequestParam(value="cursor") Long cursorId,
-            @RequestParam(value="size") Long size
-    ) {
+            @PathVariable Long missionId,
+            @RequestParam(value = "cursor") Long cursorId,
+            @RequestParam(value = "size") Long size
+            ) {
 
         SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
                 .size(size)
+                .sortStrategy(SortStrategy.CHRONOLOGICAL)
                 .postType(PostType.MISSION)
                 .build();
 

--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -2,10 +2,13 @@ package com.dope.breaking.api;
 
 import com.dope.breaking.dto.comment.CommentResponseDto;
 import com.dope.breaking.dto.mission.MissionFeedResponseDto;
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.dto.mission.MissionRequestDto;
 import com.dope.breaking.dto.mission.MissionResponseDto;
-import com.dope.breaking.dto.post.DetailPostResponseDto;
+import com.dope.breaking.dto.post.FeedResultPostDto;
+import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.service.MissionService;
+import com.dope.breaking.service.SearchFeedService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import javax.websocket.server.PathParam;
 import java.security.Principal;
 import java.util.List;
 import java.util.Map;
@@ -23,6 +27,7 @@ import java.util.Map;
 public class MissionAPI {
 
     private final MissionService missionService;
+    private final SearchFeedService searchFeedService;
 
     @PreAuthorize("isAuthenticated()")
     @PostMapping("/breaking-mission")
@@ -58,6 +63,27 @@ public class MissionAPI {
             crntUsername = principal.getName();
         }
         return missionService.readMission(missionId, crntUsername);
+    }
+
+    @GetMapping("/breaking-mission/{missionId}/feed")
+    public ResponseEntity<List<FeedResultPostDto>> searchFeed(
+            Principal principal,
+            @PathParam(value="missionId") Long missionId,
+            @RequestParam(value="cursor") Long cursorId,
+            @RequestParam(value="size") Long size
+    ) {
+
+        SearchFeedConditionDto searchFeedConditionDto = SearchFeedConditionDto.builder()
+                .size(size)
+                .postType(PostType.MISSION)
+                .build();
+
+        String username = null;
+        if(principal!=null) {
+            username = principal.getName();
+        }
+
+        return ResponseEntity.ok().body(searchFeedService.searchFeedForMission(searchFeedConditionDto, missionId, username, cursorId));
     }
 
 }

--- a/src/main/java/com/dope/breaking/domain/post/PostType.java
+++ b/src/main/java/com/dope/breaking/domain/post/PostType.java
@@ -6,11 +6,19 @@ import lombok.*;
 @ToString
 @RequiredArgsConstructor
 public enum PostType {
+
     EXCLUSIVE("EXCLUSIVE"),
     CHARGED("CHARGED"),
     FREE("FREE"),
     MISSION("MISSION");
 
-
     private final String title;
+
+    public static PostType findMatchedEnum(String str) {
+        for (PostType el : PostType.values()) {
+            if (el.name().equalsIgnoreCase(str))
+                return el;
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
+++ b/src/main/java/com/dope/breaking/dto/post/SearchFeedConditionDto.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.dto.post;
 
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.service.SoldOption;
 import com.dope.breaking.service.SortStrategy;
 import com.dope.breaking.service.UserPageFeedOption;
@@ -23,6 +24,8 @@ public class SearchFeedConditionDto {
 
     private SoldOption soldOption;
 
+    private PostType postType;
+
     private UserPageFeedOption userPageFeedOption;
 
     private LocalDateTime dateFrom;
@@ -32,12 +35,13 @@ public class SearchFeedConditionDto {
     private Integer forLastMin;
 
     @Builder
-    public SearchFeedConditionDto(String searchKeyword, String searchHashtag, Long size, SortStrategy sortStrategy, SoldOption soldOption, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
+    public SearchFeedConditionDto(String searchKeyword, String searchHashtag, Long size, SortStrategy sortStrategy, SoldOption soldOption, PostType postType, UserPageFeedOption userPageFeedOption, LocalDateTime dateFrom, LocalDateTime dateTo, Integer forLastMin) {
         this.searchKeyword = searchKeyword;
         this.searchHashtag = searchHashtag;
         this.size = size;
         this.sortStrategy = sortStrategy;
         this.soldOption = soldOption;
+        this.postType = postType;
         this.userPageFeedOption = userPageFeedOption;
         this.dateFrom = dateFrom;
         this.dateTo = dateTo;

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.post.Mission;
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.FeedResultPostDto;
@@ -13,4 +14,5 @@ public interface FeedRepositoryCustom {
 
     List<FeedResultPostDto> searchUserPageBy(SearchFeedConditionDto searchFeedConditionDto, User owner, User me, Post cursorPost);
 
+    List<FeedResultPostDto> searchFeedByMission(SearchFeedConditionDto searchFeedConditionDto, Mission mission, Post cursorPost, User me);
 }

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -64,6 +64,7 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 .from(post)
                 .where(
                         soldOption(searchFeedConditionDto.getSoldOption()),
+                        postTypeFilter(searchFeedConditionDto.getPostType()),
                         cursorPagination(cursorPost, searchFeedConditionDto.getSortStrategy()),
                         sameLevelCursorFilter(cursorPost, searchFeedConditionDto.getSortStrategy())
                 )
@@ -136,6 +137,15 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
             return null;
         } else {
             return post.isHidden.eq(false);
+        }
+    }
+
+    private Predicate postTypeFilter(PostType postType) {
+
+        if(postType == null) {
+            return null;
+        } else {
+            return post.postType.eq(postType);
         }
     }
 

--- a/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/FeedRepositoryCustomImpl.java
@@ -1,6 +1,8 @@
 package com.dope.breaking.repository;
 
+import com.dope.breaking.domain.post.Mission;
 import com.dope.breaking.domain.post.Post;
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.post.*;
 import com.dope.breaking.service.SoldOption;
@@ -96,6 +98,17 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
                 .fetch();
     }
 
+    @Override
+    public List<FeedResultPostDto> searchFeedByMission(SearchFeedConditionDto searchFeedConditionDto, Mission mission, Post cursorPost, User me) {
+        return getBaseQuery(searchFeedConditionDto, cursorPost, me)
+                .where(
+                        post.mission.eq(mission),
+                        hiddenPostFilter(mission, me)
+                )
+                .orderBy(post.id.desc())
+                .fetch();
+    }
+
     private Predicate keywordSearch(String searchString) {
 
         if(searchString == null) {
@@ -134,6 +147,15 @@ public class FeedRepositoryCustomImpl implements FeedRepositoryCustom {
     private Predicate hiddenPostFilter(User owner, User me) {
 
         if(owner == me) {
+            return null;
+        } else {
+            return post.isHidden.eq(false);
+        }
+    }
+
+    private Predicate hiddenPostFilter(Mission mission, User me) {
+
+        if(mission.getUser() == me) {
             return null;
         } else {
             return post.isHidden.eq(false);

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -106,18 +106,7 @@ public class SearchFeedService {
 
     }
 
-        }
 
-        if(me != null) {
-            for (FeedResultPostDto dto : result) {
-                dto.setIsBookmarked(bookmarkRepository.existsByUserAndPostId(me, dto.getPostId()));
-                dto.setIsLiked(postLikeRepository.existsByUserAndPostId(me, dto.getPostId()));
-            }
-        }
-
-        return result;
-
-    }
 
     public List<SearchUserResponseDto> searchUser(String username, String searchKeyword, Long cursorId, Long size) {
 
@@ -137,6 +126,32 @@ public class SearchFeedService {
             for (SearchUserResponseDto dto : result) {
                 if(followRepository.existsFollowsByFollowedIdAndFollowingId(me.getId(), dto.getUserId()))
                 dto.setIsFollowing(true);
+            }
+        }
+
+        return result;
+    }
+
+    public List<FeedResultPostDto> searchFeedForMission(SearchFeedConditionDto searchFeedConditionDto, Long missionId, String username, Long cursorId) {
+
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchBreakingMissionException::new);
+
+        User me = null;
+        if(username != null) {
+            me = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
+        }
+
+        Post cursorPost = null;
+        if(cursorId != null && cursorId != 0) {
+            cursorPost = postRepository.findById(cursorId).orElseThrow(InvalidAccessTokenException::new);
+        }
+
+        List<FeedResultPostDto> result = feedRepository.searchFeedByMission(searchFeedConditionDto, mission, cursorPost, me);
+
+        if(me != null) {
+            for (FeedResultPostDto dto : result) {
+                dto.setIsBookmarked(bookmarkRepository.existsByUserAndPostId(me, dto.getPostId()));
+                dto.setIsLiked(postLikeRepository.existsByUserAndPostId(me, dto.getPostId()));
             }
         }
 

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -7,6 +7,7 @@ import com.dope.breaking.dto.post.FeedResultPostDto;
 import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import com.dope.breaking.dto.user.SearchUserResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
+import com.dope.breaking.exception.mission.NoSuchBreakingMissionException;
 import com.dope.breaking.exception.pagination.InvalidCursorException;
 import com.dope.breaking.exception.user.LoginRequireException;
 import com.dope.breaking.exception.user.NoPermissionException;
@@ -45,6 +46,8 @@ public class FeedServiceTest {
     private PostLikeRepository postLikeRepository;
     @Mock
     private FollowRepository followRepository;
+    @Mock
+    private MissionRepository missionRepository;
 
     @InjectMocks
     private SearchFeedService feedService;
@@ -376,5 +379,15 @@ public class FeedServiceTest {
 
         assertTrue(result.get(0).getIsFollowing());
 
+    }
+
+    @DisplayName("존재하지 않는 미션일 경우, 예외가 발생한다.")
+    @Test
+    void searchMissionPostNoSuchMission() {
+
+        when(missionRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchBreakingMissionException.class,
+                () -> feedService.searchFeedForMission(SearchFeedConditionDto.builder().build(), 999L, null, null));
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #266 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 브레이킹 미션 세부 조회 화면에서, 해당 미션과 관련된 포스트를 피드로 나타냅니다.
- 미션을 개시한 언론사 본인이 미션을 상세 조회할 경우, 숨김 처리 된 제보를 피드를 볼 수 있습니다.
- 다른 유저가 미션을 상세 조회할 경우, 숨김 처리된 제보를 피드에서 볼수 없습니다.
- 게시글을 숨긴 본인이 피드를 조회할 때도, 미션 피드에서는 나타내지 않습니다. (본인 유저 페이지에서 확인 가능)

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/185618128-3476595f-c56c-4f2d-86a2-873ea638013d.png)

