### PR TITLE
feat: implement watermark on media

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,7 @@ dependencies {
 	runtimeOnly 'mysql:mysql-connector-java'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation group: 'net.coobird', name: 'thumbnailator', version: '0.4.11'
-	implementation group: 'org.jcodec', name: 'jcodec', version: '0.2.5'
-	implementation group: 'org.jcodec', name: 'jcodec-javase', version: '0.2.5'
+	implementation group: 'net.bramp.ffmpeg', name: 'ffmpeg', version: '0.7.0'
 	implementation 'com.github.maricn:logback-slack-appender:1.4.0'
 
 }

--- a/src/main/java/com/dope/breaking/domain/media/UploadType.java
+++ b/src/main/java/com/dope/breaking/domain/media/UploadType.java
@@ -12,7 +12,9 @@ public enum UploadType {
 
     COMPRESSED_PROFILE_IMG("compressedProfileImgDirName", "/compressedProfileImg"),
     ORIGINAL_POST_MEDIA("originalPostMediaDirName","/originalPostMedia"),
-    THUMBNAIL_POST_MEDIA("thumbnailDirName" ,"/thumbnailPostMedia");
+    THUMBNAIL_POST_MEDIA("thumbnailDirName" ,"/thumbnailPostMedia"),
+
+    POST_MEDIA_DOWNLOAD("postMediaDownload", "/postMediaDownload");
 
     private final String uploadDivision;
     private final String DirName;

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -6,15 +6,15 @@ import com.dope.breaking.domain.media.UploadType;
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.exception.CustomInternalErrorException;
 import com.dope.breaking.repository.MediaRepository;
-import com.dope.breaking.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-import org.jcodec.api.FrameGrab;
-import org.jcodec.api.JCodecException;
-import org.jcodec.common.io.NIOUtils;
-import org.jcodec.common.model.Picture;
-import org.jcodec.scale.AWTUtil;
+import net.bramp.ffmpeg.FFmpeg;
+import net.bramp.ffmpeg.FFmpegExecutor;
+import net.bramp.ffmpeg.FFprobe;
+import net.bramp.ffmpeg.builder.FFmpegBuilder;
+import net.coobird.thumbnailator.Thumbnails;
+import net.coobird.thumbnailator.geometry.Positions;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -26,6 +26,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.imageio.ImageIO;
 import java.awt.*;
+import java.awt.font.FontRenderContext;
+import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
@@ -41,7 +43,6 @@ import java.util.List;
 public class MediaService {
 
     private final MediaRepository mediaRepository;
-    private final PostRepository postRepository;
 
     private final String MAIN_DIR_NAME = System.getProperty("user.dir") + "/src/main/webapp/WEB-INF";
     private final String SUB_DIR_NAME = "/static";
@@ -63,7 +64,7 @@ public class MediaService {
         List<String> fileNameList = new ArrayList<String>();
 
         try {
-            File folder = new File(MAIN_DIR_NAME + SUB_DIR_NAME +uploadType.getDirName());
+            File folder = new File(MAIN_DIR_NAME + SUB_DIR_NAME + uploadType.getDirName());
 
             if (!folder.exists()) {
                 folder.mkdirs();
@@ -155,6 +156,17 @@ public class MediaService {
         }
     }
 
+    public void deleteWatermarkNickname(String fileName){
+        File nicknameTextImagePath = new File(fileName);
+        if (nicknameTextImagePath.exists()) {
+            if (nicknameTextImagePath.delete()) {
+                log.info("파일삭제 성공. filename : {}", nicknameTextImagePath);
+            } else {
+                log.info("파일삭제 실패. filename : {}", nicknameTextImagePath);
+            }
+        }
+    }
+
 
     public String compressImage(String originalProfileImgURL) {
 
@@ -163,7 +175,9 @@ public class MediaService {
         String compressedProfileImgFolderName = SUB_DIR_NAME + UploadType.COMPRESSED_PROFILE_IMG.getDirName();
         File compressedProfileImgFolder = new File(MAIN_DIR_NAME + compressedProfileImgFolderName);
 
-        if(!compressedProfileImgFolder.exists()){compressedProfileImgFolder.mkdirs();}
+        if (!compressedProfileImgFolder.exists()) {
+            compressedProfileImgFolder.mkdirs();
+        }
 
         String extension = originalProfileImgURL.substring(originalProfileImgURL.lastIndexOf(".") + 1);
         MediaType mediaType = findMediaType(extension);
@@ -178,28 +192,28 @@ public class MediaService {
             throw new CustomInternalErrorException(e.getMessage());
         }
 
+
         int width = oImage.getWidth();
         int height = oImage.getHeight();
 
-        if (Math.min(width,height)>=500){
-            if(width<height){
-                height = Math.round(height*500/width);
+        if (Math.min(width, height) >= 500) {
+            if (width < height) {
+                height = Math.round(height * 500 / width);
                 width = 500;
-            }
-            else{
-                width = Math.round(width*500/height);
+            } else {
+                width = Math.round(width * 500 / height);
                 height = 500;
             }
         }
-        
-        BufferedImage tImage = new BufferedImage(width,height, BufferedImage.TYPE_3BYTE_BGR);
+
+        BufferedImage tImage = new BufferedImage(width, height, BufferedImage.TYPE_3BYTE_BGR);
 
         Graphics2D graphic = tImage.createGraphics();
-        Image image = oImage.getScaledInstance(width,height,Image.SCALE_SMOOTH);
-        graphic.drawImage(image,0,0,width,height,null);
+        Image image = oImage.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+        graphic.drawImage(image, 0, 0, width, height, null);
         graphic.dispose();
         try {
-            ImageIO.write(tImage,extension,destination);
+            ImageIO.write(tImage, extension, destination);
         } catch (IOException e) {
             throw new CustomInternalErrorException(e.getMessage());
         }
@@ -207,7 +221,87 @@ public class MediaService {
         return compressedImageURL;
     }
 
-    public String makeThumbnail(String mediaUrl) throws IOException, JCodecException { //파일 주소를 받는다.
+
+    public List<String> makeWatermarkMedia(List<String> mediaURLList, String watermarkImageURL, UploadType uploadType) throws IOException {
+
+
+        List<String> watermarkMedia = new LinkedList<>();
+
+        File folder = new File(MAIN_DIR_NAME + SUB_DIR_NAME + File.separator + uploadType.getDirName());
+
+        //폴더가 존재하는지 확인 -> 없다면 생성
+        if (!folder.exists()) {
+            folder.mkdirs();
+        }
+
+        String watermarkDestinationPath = null;
+
+        BufferedImage nicknameTextImage = ImageIO.read(new File(watermarkImageURL));
+
+        for (String mediaURL : mediaURLList) {
+
+            String extension = mediaURL.substring(mediaURL.lastIndexOf(".") + 1);
+            MediaType mediaType = findMediaType(extension);
+
+
+            String FullPath = MAIN_DIR_NAME + mediaURL;
+            File originalMediaPath = new File(FullPath); //전체 주소 경로를 받음
+            try {
+                if (mediaType.equals(MediaType.PHOTO)) {
+
+                    String generateWatermarkName = "w_" + UUID.randomUUID().toString() + "." + extension; //w_ 접두사로 이미지파일 생성
+                    watermarkDestinationPath = SUB_DIR_NAME + UploadType.ORIGINAL_POST_MEDIA.getDirName() + File.separator + generateWatermarkName;
+                    File thumbDestination = new File(MAIN_DIR_NAME + watermarkDestinationPath);
+                    BufferedImage oImage = ImageIO.read(originalMediaPath);
+                    int originalHeight = oImage.getHeight();
+                    int originalWidth = oImage.getWidth();
+                    Thumbnails.of(oImage)
+                            .size(originalWidth, originalHeight)
+                            .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 0.5f)
+                            .outputQuality(1.0f)
+                            .toFile(thumbDestination);
+
+
+                    watermarkMedia.add(watermarkDestinationPath);
+                } else {
+                    //MacOS
+                    FFmpeg fFmpeg = new FFmpeg("/usr/local/bin/ffmpeg");
+                    FFprobe fFprobe = new FFprobe("/usr/local/bin/ffprobe");
+
+                    //UbuntuOS
+//                FFmpeg fFmpeg = new FFmpeg("/usr/bin/ffmpeg");
+//                FFprobe fFprobe = new FFprobe("/usr/bin/ffprobe");
+
+
+                    String videofile = originalMediaPath.getPath();
+                    String generateWatermarkName = "w_" + UUID.randomUUID().toString() + ".mp4";
+                    watermarkDestinationPath = SUB_DIR_NAME + UploadType.ORIGINAL_POST_MEDIA.getDirName() + File.separator + generateWatermarkName;
+                    FFmpegBuilder fFmpegBuilder = new FFmpegBuilder()
+                            .setInput(videofile)
+                            .addInput(watermarkImageURL)
+                            .addExtraArgs("-filter_complex", "overlay=x=main_w-overlay_w-(main_w*0.01):y=main_h-overlay_h-(main_h*0.01)")
+                            .addOutput(MAIN_DIR_NAME + watermarkDestinationPath)
+                            .addExtraArgs("-preset", "ultrafast")
+                            .done();
+
+                    FFmpegExecutor executor = new FFmpegExecutor(fFmpeg, fFprobe);
+                    executor.createJob(fFmpegBuilder).run();
+
+                    watermarkMedia.add(watermarkDestinationPath);
+                }
+            } catch (IllegalArgumentException e) {
+                e.getMessage();
+                log.info("미디어 포맷을 읽을 수 없습니다.");
+                return null;
+            }
+        }
+
+        return watermarkMedia;
+
+    }
+
+
+    public String makeThumbnail(String mediaUrl, String watermarkImageURL) throws IOException { //파일 주소를 받는다.
         String FullPath = MAIN_DIR_NAME + mediaUrl;
         File originalMediaPath = new File(FullPath); //전체 주소 경로를 받음
         File thumbnailFolder = new File(MAIN_DIR_NAME + SUB_DIR_NAME + File.separator + UploadType.THUMBNAIL_POST_MEDIA.getDirName());
@@ -220,13 +314,16 @@ public class MediaService {
         String extension = mediaUrl.substring(mediaUrl.lastIndexOf(".") + 1);
         MediaType mediaType = findMediaType(extension);
 
+        BufferedImage nicknameTextImage = ImageIO.read(new File(watermarkImageURL));
+
         final int tWidth = 400;
         final int tHeight = 300;
 
         try {
             if (mediaType.equals(MediaType.PHOTO)) {
+
                 generateThumbFileName = "s_" + UUID.randomUUID().toString() + "." + extension;
-                String thumbDestinationPath =  SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator  + generateThumbFileName;
+                String thumbDestinationPath = SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
                 File thumbDestination = new File(MAIN_DIR_NAME + thumbDestinationPath);
                 BufferedImage oImage = ImageIO.read(originalMediaPath);
                 BufferedImage tImage = new BufferedImage(tWidth, tHeight, BufferedImage.TYPE_3BYTE_BGR);
@@ -234,32 +331,94 @@ public class MediaService {
                 Image image = oImage.getScaledInstance(tWidth, tHeight, Image.SCALE_SMOOTH);
                 graphic.drawImage(image, 0, 0, tWidth, tHeight, null);
                 graphic.dispose();
-                ImageIO.write(tImage, "png", thumbDestination);
+                Thumbnails.of(tImage)
+                        .size(400, 300)
+                        .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 0.5f)
+                        .outputQuality(1.0f)
+                        .toFile(thumbDestination);
 
                 return thumbDestinationPath;
             } else {
-                FrameGrab grab = FrameGrab.createFrameGrab(NIOUtils.readableChannel(originalMediaPath));
-                double startSec = 1;
-                grab.seekToSecondPrecise(startSec);
-                Picture picture = grab.getNativeFrame();
-                BufferedImage oImage = AWTUtil.toBufferedImage(picture);
+                //MacOS
+                FFmpeg fFmpeg = new FFmpeg("/usr/local/bin/ffmpeg");
+                FFprobe fFprobe = new FFprobe("/usr/local/bin/ffprobe");
+
+                //UbuntuOS
+//                FFmpeg fFmpeg = new FFmpeg("/usr/bin/ffmpeg");
+//                FFprobe fFprobe = new FFprobe("/usr/bin/ffprobe");
+
+
+                String videofile = originalMediaPath.getPath();
                 generateThumbFileName = "s_" + UUID.randomUUID().toString() + ".png";
-                String thumbDestinationPath = SUB_DIR_NAME +UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
-                File thumdestination = new File(MAIN_DIR_NAME + thumbDestinationPath);
+                String thumbDestinationPath = MAIN_DIR_NAME + SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
+                FFmpegBuilder fFmpegBuilder = new FFmpegBuilder()
+                        .setInput(videofile)
+                        .addOutput(thumbDestinationPath)
+                        .addExtraArgs("-ss", "00:00:01")
+                        .addExtraArgs("-preset", "ultrafast")
+                        .setFrames(1)
+                        .done();
+
+                FFmpegExecutor executor = new FFmpegExecutor(fFmpeg, fFprobe);
+                executor.createJob(fFmpegBuilder).run();
+
+                File thumbDestination = new File(thumbDestinationPath);
                 BufferedImage tImage = new BufferedImage(tWidth, tHeight, BufferedImage.TYPE_3BYTE_BGR); // 썸네일이미지
                 Graphics2D graphic = tImage.createGraphics();
+                BufferedImage oImage = ImageIO.read(thumbDestination);
                 Image image = oImage.getScaledInstance(tWidth, tHeight, Image.SCALE_SMOOTH);
                 graphic.drawImage(image, 0, 0, tWidth, tHeight, null);
                 graphic.dispose();
-                ImageIO.write(tImage, "png", thumdestination);
+
+                Thumbnails.of(tImage)
+                        .size(400, 300)
+                        .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1.0f)
+                        .outputQuality(1.0f)
+                        .toFile(thumbDestination);
+
 
                 return thumbDestinationPath;
             }
-        } catch (JCodecException| IllegalArgumentException e) {
+        } catch (IllegalArgumentException e) {
             e.getMessage();
             log.info("미디어 포맷을 읽을 수 없습니다.");
             return null;
         }
+    }
+
+
+
+    public String makeWatermarkNickname(String nickname) throws IOException {
+        try {
+            //워터마크 이미지 생성
+            String nicknameText = nickname != null ? "@" + nickname : "@Breaking";
+            File nicknameTextImagePath = new File(MAIN_DIR_NAME + SUB_DIR_NAME + File.separator + UUID.randomUUID() + ".png");
+            Font font = new Font(null, Font.PLAIN, 50);
+            FontRenderContext frc = new FontRenderContext(null, true, true);
+            Rectangle2D bounds = font.getStringBounds(nicknameText, frc);
+            int backgroundWidth = (int) bounds.getWidth();
+            int backgroundHeight = (int) bounds.getHeight();
+            BufferedImage nicknameTextImage = new BufferedImage(backgroundWidth, backgroundHeight, BufferedImage.TYPE_INT_ARGB);
+
+            Graphics2D g2D = nicknameTextImage.createGraphics();
+            g2D.setColor(Color.WHITE);
+            g2D.fillRect(0, 0, backgroundWidth, backgroundHeight);
+            g2D.setColor(Color.BLACK);
+            g2D.setFont(font);
+            g2D.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+            g2D.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+            g2D.setRenderingHint(RenderingHints.KEY_DITHERING, RenderingHints.VALUE_DITHER_ENABLE);
+            g2D.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+
+            g2D.drawString(nicknameText, (float) bounds.getX(), (float) -bounds.getY());
+            g2D.dispose();
+
+            ImageIO.write(nicknameTextImage, "PNG", nicknameTextImagePath);
+            return nicknameTextImagePath.getPath();
+        }catch(IOException e){
+            log.info(e.getMessage());
+        }
+        throw new CustomInternalErrorException("워터마크를 생성할 수 없습니다.");
     }
 
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #262 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 이미지 및 동영상에 워터마크를 삽입하는 기능을 추가하였습니다. 
 - 로그인한 유저가 게시글을 등록 시, 유저의 닉네임을 워터마크로 삽입하였습니다.
 - 익명의 게시글로 게시글을 등록 시, @Breaking으로 워터마크를 삽입하였습니다.
 - 오른쪽 하단에 워터마크를 삽입합니다.

2. 기존의 jcodec 라이브러릴에서 FFmpeg 라이브러리를 사용함으로써 다양한 코덱 및 영상 포맷을 읽을 수 있도록 하였습니다.
 - 따라서 로컬 환경 및 실 서버에서 FFmpeg 외부 프로그램이 설치가 되어야 합니다. 설치 및 경로는 추후 wiki에 문서화 하여 공유하도록 하겠습니다.

3. 게시글 조회 시, 워터마크가 적용된 파일들을 반환하도록 하였습니다. 

4. 디렉토리를 추가하여 워터마크만 담기도록 구현하였습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="1589" alt="스크린샷 2022-08-21 오후 12 47 22" src="https://user-images.githubusercontent.com/62254434/185775888-36fdab39-e060-42d5-9821-038236eea560.png">
<img width="406" alt="스크린샷 2022-08-21 오후 1 33 00" src="https://user-images.githubusercontent.com/62254434/185775894-3de0266b-ff45-43cc-9b65-c491efd7d835.png">
<img width="777" alt="스크린샷 2022-08-21 오후 1 33 15" src="https://user-images.githubusercontent.com/62254434/185775898-3c1d4bf3-b352-4cfb-81f2-427457be2d86.png">
<img width="801" alt="스크린샷 2022-08-21 오후 1 33 44" src="https://user-images.githubusercontent.com/62254434/185
<img width="684" alt="스크린샷 2022-08-21 오후 1 35 22" src="https://user-images.githubusercontent.com/62254434/185775911-c93459cd-a3f6-4a57-a955-40dbb0c6ec13.png">
775906-39d76df0-d9d7-4c57-8a0e-58a5f1a4a1b0.png">
각 테스트는 이상없이 모두 양호합니다.


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

일단, 워터마크 생성의 기능이 시간을 많이 잡아먹습니다.. 추후에 비트레이트를 공부해서 좀 건드린 다음에 성능을 더욱 뽑아내야겠습니다.

자신의 환경에 FFmpeg를 필히 설치 후 로컬에 내려받으시길 바랍니다.