### PR TITLE
feat: implement user withdraw

### DIFF
--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -69,6 +69,14 @@ public class UserAPI {
     }
 
     @PreAuthorize("isAuthenticated()")
+    @PostMapping("/oauth2/sign-out")
+    public ResponseEntity<FullUserInformationResponse> signOut(Principal principal) {
+
+        userService.signOut(principal.getName());
+        return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("isAuthenticated()")
     @PutMapping(value = "/profile", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> profileUpdateConfirm(
             Principal principal,
@@ -93,4 +101,5 @@ public class UserAPI {
     public ResponseEntity<FullUserInformationResponse> fullUserInformation(Principal principal) {
         return ResponseEntity.ok().body(userService.getFullUserInformation(principal.getName()));
     }
+
 }

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -60,7 +60,7 @@ public class UserAPI {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/oauth2/delete-user", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(Principal principal,
                                     @RequestPart String signUpRequest,
                                     @RequestPart(required = false) List<MultipartFile> profileImg, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {
@@ -69,10 +69,10 @@ public class UserAPI {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/oauth2/sign-out")
+    @PostMapping("/oauth2/withdraw")
     public ResponseEntity<FullUserInformationResponse> signOut(Principal principal) {
 
-        userService.signOut(principal.getName());
+        userService.withdraw(principal.getName());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/dope/breaking/api/UserAPI.java
+++ b/src/main/java/com/dope/breaking/api/UserAPI.java
@@ -60,7 +60,7 @@ public class UserAPI {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping(value = "/oauth2/delete-user", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/oauth2/sign-up", consumes = {MediaType.TEXT_PLAIN_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<?> signUp(Principal principal,
                                     @RequestPart String signUpRequest,
                                     @RequestPart(required = false) List<MultipartFile> profileImg, HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse) throws ServletException, IOException {

--- a/src/main/java/com/dope/breaking/domain/user/User.java
+++ b/src/main/java/com/dope/breaking/domain/user/User.java
@@ -90,6 +90,19 @@ public class User {
         this.password = UUID.randomUUID().toString();
     }
 
+    public void removeUserInformation () {
+
+        this.originalProfileImgURL = null;
+        this.compressedProfileImgURL = null;
+        this.nickname = "탈퇴한 유저";
+        this.realName = "탈퇴한 유저";
+        this.password = "탈퇴한 유저";
+        this.statusMsg = null;
+        this.email = null;
+        this.phoneNumber = null;
+        this.username = null;
+    }
+
     @Enumerated(EnumType.STRING)
     private Role role; //권한 종류
 

--- a/src/main/java/com/dope/breaking/repository/BookmarkRepository.java
+++ b/src/main/java/com/dope/breaking/repository/BookmarkRepository.java
@@ -13,4 +13,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByUserAndPost(User user, Post post);
 
     Boolean existsByUserAndPostId(User me, Long postId);
+
+    void deleteAllByUser(User user);
 }

--- a/src/main/java/com/dope/breaking/repository/FollowRepository.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepository.java
@@ -20,4 +20,8 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
     void deleteByFollowedAndFollowing(User followed, User following);
 
     boolean existsFollowsByFollowedIdAndFollowingId(Long followed, Long following);
+
+    void deleteAllByFollowing(User user);
+
+    void deleteAllByFollowed(User user);
 }

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -378,7 +378,7 @@ public class UserService {
     }
 
     @Transactional
-    public void signOut(String username) {
+    public void withdraw(String username) {
 
         User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
         followRepository.deleteAllByFollowing(user);

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -97,7 +97,7 @@ class UserAPITest {
 
         userRepository.save(user);
 
-        this.mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/sign-out"))
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/withdraw"))
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
     }

--- a/src/test/java/com/dope/breaking/api/UserAPITest.java
+++ b/src/test/java/com/dope/breaking/api/UserAPITest.java
@@ -5,16 +5,23 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.user.ProfileInformationResponseDto;
 import com.dope.breaking.dto.user.SignUpRequestDto;
 import com.dope.breaking.repository.UserRepository;
+import com.dope.breaking.withMockCustomAuthorize.WithMockCustomUser;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Locale;
+import java.util.UUID;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -28,6 +35,7 @@ class UserAPITest {
 
     @Autowired private MockMvc mockMvc;
     @Autowired private UserRepository userRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
 
     @Test
     void getProfileInformationSuccess() throws Exception {
@@ -75,6 +83,33 @@ class UserAPITest {
         mockMvc.perform(get("/profile/" + 1000000000))
                 .andExpect(status().isNotFound());
 
+    }
+
+    @DisplayName("유저를 회원탈퇴 시킨다.")
+    @Test
+    @WithMockCustomUser
+    void signOutSuccess() throws Exception {
+        User user = User.builder()
+                .username("12345g")
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .role(Role.USER) // 최초 가입시 USER 로 설정
+                .build();
+
+        userRepository.save(user);
+
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/sign-out"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("회원 탈퇴 시, 유저가 존재하지 않으면 예외가 발생한다.")
+    @Test
+    @WithMockCustomUser
+    void signOutFailure() throws Exception {
+
+        this.mockMvc.perform(MockMvcRequestBuilders.post("/oauth2/sign-out"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().is4xxClientError());
     }
 
 }

--- a/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/BookmarkRepositoryTest.java
@@ -2,7 +2,9 @@ package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Post;
 import com.dope.breaking.domain.user.Bookmark;
+import com.dope.breaking.domain.user.Follow;
 import com.dope.breaking.domain.user.User;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,5 +34,32 @@ public class BookmarkRepositoryTest {
         bookmarkRepository.save(bookmark);
 
         assertTrue(bookmarkRepository.existsByUserAndPostId(user, post.getId()));
+    }
+
+    @DisplayName("특정 유저의 팔로잉 및 북마크 목록이 모두 삭제된다.")
+    @Test
+    void deleteAllBookmarkByUser() {
+
+        User user = new User();
+        userRepository.save(user);
+
+        User otherUser = new User();
+        userRepository.save(otherUser);
+
+        Post post1 = Post.builder().build();
+        Post post2 = Post.builder().build();
+        postRepository.save(post1);
+        postRepository.save(post2);
+
+        bookmarkRepository.save(new Bookmark(user, post1));
+        bookmarkRepository.save(new Bookmark(user, post2));
+        bookmarkRepository.save(new Bookmark(otherUser, post1));
+
+        Long preBookmarkCount = bookmarkRepository.count();
+
+        bookmarkRepository.deleteAllByUser(user);
+
+        Assertions.assertEquals(3, preBookmarkCount);
+        Assertions.assertEquals(1, bookmarkRepository.count());
     }
 }

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -339,4 +339,26 @@ class FollowRepositoryTest {
 
     }
 
+    @DisplayName("특정 유저의 팔로잉 및 팔로우 목록이 모두 삭제된다.")
+    @Test
+    void deleteAllFollowByUser(){
+
+        User user = new User();
+        userRepository.save(user);
+        User otherUser = new User();
+        userRepository.save(otherUser);
+
+        followRepository.save(new Follow(user, otherUser));
+        followRepository.save(new Follow(otherUser, user));
+
+        int preFollowCount = followRepository.countFollowsByFollowed(user) + followRepository.countFollowsByFollowing(user);
+
+        followRepository.deleteAllByFollowed(user);
+        followRepository.deleteAllByFollowing(user);
+
+        Assertions.assertEquals(2, preFollowCount);
+        Assertions.assertEquals(0, followRepository.countFollowsByFollowed(user) + followRepository.countFollowsByFollowing(user));
+
+    }
+
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #274 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
@Martin0o0 파일 삭제 관련해서 자세하게 확인 부탁


DB 처리
- (프로필, username, phonenumber, email 등 중복 위험이나 개인정보와 관련된 정보) null처리
- 닉네임 "알 수 없음"
- 팔로우/팔로잉 삭제
- 좋아요, 북마크 삭제
- 프로필 원본 및 압축파일 삭제

정책
- 유저 프로필에는 접근 불가능
- 게시글은 정상적으로 접근 가능(피드, 구매한 게시글, 북마크한 게시글 등을 통해..)
- 댓글 삭제하지 않음
- 탈퇴한 유저가 회원 가입 시 (당연히 기존 데이터를 살려주지는 않음.)
case1 : 탈퇴 후 그냥 바로 가입 가능
case2 : 탈퇴 정보 관리를 위한DB 테이블을 만들어서, email 정보와 탈퇴일 정보를 보관하고, n일 후 재가입 가능으로 처리

Access Token, Refresh Token은 터치하지 않았습니다.
username을 null 처리 했기 때문에, 동일한 access token을 가지고 다음 로그인 시에 존재하지 않은 유저가 됩니다.