### PR TITLE
feat: change post type when mission is over

### DIFF
--- a/src/main/java/com/dope/breaking/domain/post/Post.java
+++ b/src/main/java/com/dope/breaking/domain/post/Post.java
@@ -129,4 +129,6 @@ public class Post extends BaseTimeEntity {
 
     public void updateIsHidden (boolean isHidden) { this.isHidden = isHidden; }
 
+    public void updatePostType (PostType postType) { this.postType = postType; }
+
 }

--- a/src/main/java/com/dope/breaking/exception/ErrorCode.java
+++ b/src/main/java/com/dope/breaking/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
 
     NO_SUCH_BREAKING_MISSION("BSE480", "존재하지 않는 브레이킹미션입니다."),
     MISSION_ONLY_FOR_PRESS("BSE481", "브레이킹 미션은 언론사만 게시 가능합니다."),
+    ALREADY_PURCHASED_POST("BSE483","이미 구매한 제보입니다."),
 
 
     INTERNAL_SERVER_ERROR("BSE500", "서버 요청 처리 실패."),

--- a/src/main/java/com/dope/breaking/exception/post/AlreadyPurchasedPostException.java
+++ b/src/main/java/com/dope/breaking/exception/post/AlreadyPurchasedPostException.java
@@ -4,8 +4,8 @@ import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.ErrorCode;
 import org.springframework.http.HttpStatus;
 
-public class NoSuchPostException extends BreakingException {
+public class AlreadyPurchasedPostException extends BreakingException {
 
-    public NoSuchPostException() {super(ErrorCode.NO_SUCH_POST, HttpStatus.NOT_FOUND);}
+    public AlreadyPurchasedPostException() { super(ErrorCode.ALREADY_PURCHASED_POST, HttpStatus.BAD_REQUEST); }
 
 }

--- a/src/main/java/com/dope/breaking/service/PurchaseService.java
+++ b/src/main/java/com/dope/breaking/service/PurchaseService.java
@@ -7,6 +7,7 @@ import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.user.ForListInfoResponseDto;
 import com.dope.breaking.exception.auth.InvalidAccessTokenException;
 import com.dope.breaking.exception.financial.NotEnoughBalanceException;
+import com.dope.breaking.exception.post.AlreadyPurchasedPostException;
 import com.dope.breaking.exception.post.NoSuchPostException;
 import com.dope.breaking.exception.post.NotPurchasablePostException;
 import com.dope.breaking.exception.post.SoldExclusivePostException;
@@ -42,6 +43,10 @@ public class PurchaseService {
 
         if (!post.getIsPurchasable()) {
             throw new NotPurchasablePostException();
+        }
+
+        if(purchaseRepository.existsByPostAndUser(post, buyer)){
+            throw new AlreadyPurchasedPostException();
         }
 
         if (post.getPostType() == PostType.FREE) {
@@ -168,7 +173,5 @@ public class PurchaseService {
         return purchaseRepository.purchaseList(user, post, cursorId, size);
 
     }
-
-
 
 }

--- a/src/test/java/com/dope/breaking/api/MissionAPITest.java
+++ b/src/test/java/com/dope/breaking/api/MissionAPITest.java
@@ -182,7 +182,7 @@ class MissionAPITest {
 
     }
 
-    @DisplayName("missionId가 유효하지 않은 경우, 예외가 발생한다.")
+    @DisplayName("유저네임이 일치할 때 미션을 수행할 경우, 제보가 문제 없이 생성된다.")
     @WithMockCustomUser
     @Transactional
     @Test
@@ -195,7 +195,9 @@ class MissionAPITest {
         User press = new User();
         userRepository.save(press);
 
-        Mission mission = new Mission(user,"title","content",null,null,null);
+        LocalDateTime endTime = LocalDateTime.of(2030, Month.AUGUST, 20, 19, 30, 40);
+
+        Mission mission = new Mission(user,"title","content",null,endTime,null);
         missionRepository.save(mission);
 
         MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
@@ -234,7 +236,60 @@ class MissionAPITest {
 
     }
 
-    @DisplayName("유저네임이 일치할 때 미션을 수행할 경우, 제보가 문제 없이 생성된다.")
+    @DisplayName("미션 제한 시간이 경과할 경우, 제보유형이 바뀐다.")
+    @WithMockCustomUser
+    @Transactional
+    @Test
+    void postTypeChangeWhenMissionEndTimeOver() throws Exception {
+
+        //Given
+        User user = new User("12345g",passwordEncoder.encode(UUID.randomUUID().toString()), Role.USER);
+        userRepository.save(user);
+
+        User press = new User();
+        userRepository.save(press);
+
+        LocalDateTime endTime = LocalDateTime.of(2020, Month.AUGUST, 20, 19, 30, 40);
+
+        Mission mission = new Mission(user,"title","content",null, endTime,null);
+        missionRepository.save(mission);
+
+        MockMultipartFile multipartFile1 = new MockMultipartFile("file", "test1.png", "image/png", new FileInputStream(System.getProperty("user.dir") + "/src/test/java/com/dope/breaking/files/test1.png"));
+
+        String json = "{" +
+                "\"title\" : \"hello\"," +
+                "\"content\" : \"content\"," +
+                "\"price\" : 123," +
+                "\"isAnonymous\" : \"false\"," +
+                "\"postType\" : \"mission\"," +
+                "\"eventDate\" : \"2020-01-01 14:01:01\"," +
+                "\"location\" : {" +
+                " \"address\" : \"address\"," +
+                "\"longitude\" : 12.1234," +
+                "\"latitude\" : 12.12345," +
+                "\"region_1depth_name\" : \"region_1depth_name\"," +
+                "\"region_2depth_name\" : \"region_2depth_name\" " +
+                "}," +
+                "\"hashtagList\" : [" +
+                "\"hello\", \"hello2\"]," +
+                "\"thumbnailIndex\" : 0" +
+                "}";
+
+        //When
+        this.mockMvc.perform(MockMvcRequestBuilders.multipart("/breaking-mission/{missionId}", mission.getId())
+                        .file(multipartFile1)
+                        .part(new MockPart("data", json.getBytes(StandardCharsets.UTF_8)))
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                        .characterEncoding("UTF-8"))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());  //Then
+
+        //Then
+        Assertions.assertEquals(PostType.CHARGED,postRepository.findAll().get(0).getPostType());
+
+    }
+
+    @DisplayName("missionId가 유효하지 않은 경우, 예외가 발생한다.")
     @WithMockCustomUser
     @Transactional
     @Test


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #266

## 예상 리뷰 시간
5-min


## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->


-  미션 종료시 구매 되지 않은 제보의 타입을 변경하는 기능을 추가했습니다.
   - 판매액이 0원일 경우, 무료제보로 변경됩니다.
   - 판매액이 0원 이상일 경우, 공개제보로 변경됩니다.

- 추가로, 본인이 구매한 제보를 재구매 하지 못하도록 예외처리를 했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
