### PR TITLE
fix: handle RequestRejectedException to response 400 error

### DIFF
--- a/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
+++ b/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
@@ -34,6 +34,7 @@ public class CustomExceptionHandler {
         e.printStackTrace(new PrintWriter(sw));
         String stacktraceAsString = sw.toString();
 
+        log.error("e.getMessage() = " + e.getMessage());
         log.error(stacktraceAsString);
 
         return ResponseEntity

--- a/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
+++ b/src/main/java/com/dope/breaking/api/CustomExceptionHandler.java
@@ -8,6 +8,7 @@ import com.dope.breaking.exception.NotValidRequestBodyException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.web.firewall.RequestRejectedException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -18,6 +19,14 @@ import java.io.StringWriter;
 @ControllerAdvice
 public class CustomExceptionHandler {
 
+    @ExceptionHandler(RequestRejectedException.class)
+    protected ResponseEntity<ErrorResponseDto> handleRequestRejectedException(RequestRejectedException e) {
+
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDto(ErrorCode.BAD_REQUEST));
+    }
+
     @ExceptionHandler(CustomInternalErrorException.class)
     protected ResponseEntity<ErrorResponseDto> handleCustomInternalErrorException(CustomInternalErrorException e) {
 
@@ -26,13 +35,11 @@ public class CustomExceptionHandler {
         String stacktraceAsString = sw.toString();
 
         log.error(stacktraceAsString);
-        System.out.println("e.getMessage() = " + e.getMessage());
 
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ErrorResponseDto(ErrorCode.INTERNAL_SERVER_ERROR));
     }
-
 
     @ExceptionHandler(BreakingException.class)
     protected ResponseEntity<ErrorResponseDto> handleBreakingCustomException(BreakingException e) {
@@ -43,12 +50,10 @@ public class CustomExceptionHandler {
                 .body(new ErrorResponseDto(e.getErrorCode()));
     }
 
-
     @ExceptionHandler(NotValidRequestBodyException.class)
     protected  ResponseEntity<ErrorResponseDto> handleNotValidRequestBody(NotValidRequestBodyException e){
         log.info(e.getMessage());
         return ResponseEntity.status(e.getStatus()).body(new ErrorResponseDto(e.getErrorCode(), e.getMessage()));
     }
-
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #277 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->


정상적이지 않은 URL 파라미터로 접근 시, 스프링 시큐리티에서 RequestRejectedException 을 반환함.

그런데 해당 요청은 클라이언트의 잘못된 요청임에도 불구하고, 500번대 internal server error를 발생시킴.
때문에 slack error log로 계속 올라와서 피곤했었어요..

시큐리티 개발자분도 개선에 동의하고, 다음 major release에 반영할 것이라고 말하고 있네요.


참고 이슈
https://github.com/spring-projects/spring-security/issues/7568
![image](https://user-images.githubusercontent.com/76773202/186353172-598d7592-c721-4702-bc1a-c0eda182d4ab.png)


## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/76773202/186352761-62d9dc48-d470-41f5-9a13-00e4d810dd6f.png)
