### PR TITLE
fix: isfollowing bug in searching user

### DIFF
--- a/src/main/java/com/dope/breaking/repository/FollowRepository.java
+++ b/src/main/java/com/dope/breaking/repository/FollowRepository.java
@@ -19,5 +19,5 @@ public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRep
 
     void deleteByFollowedAndFollowing(User followed, User following);
 
-    boolean existsFollowsByFollowedIdAndFollowingId(Long followed, Long following);
+    boolean existsFollowsByFollowingIdAndFollowedId(Long followed, Long following);
 }

--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -124,7 +124,7 @@ public class SearchFeedService {
 
         if(me != null) {
             for (SearchUserResponseDto dto : result) {
-                if(followRepository.existsFollowsByFollowedIdAndFollowingId(me.getId(), dto.getUserId()))
+                if(followRepository.existsFollowsByFollowingIdAndFollowedId(me.getId(), dto.getUserId()))
                 dto.setIsFollowing(true);
             }
         }

--- a/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/FollowRepositoryTest.java
@@ -339,4 +339,15 @@ class FollowRepositoryTest {
 
     }
 
+    @DisplayName("내가 팔로잉 하고 있는 유저라면, true가 반환된다.")
+    @Test
+    void existsFollowsByFollowingIdAndFollowedId() {
+        User user = new User();
+        userRepository.save(user);
+        User followed = new User();
+        userRepository.save(followed);
+        Follow follow = new Follow(user, followed);
+        followRepository.save(follow);
+        assertTrue(followRepository.existsFollowsByFollowingIdAndFollowedId(user.getId(), followed.getId()));
+    }
 }

--- a/src/test/java/com/dope/breaking/service/FeedServiceTest.java
+++ b/src/test/java/com/dope/breaking/service/FeedServiceTest.java
@@ -369,7 +369,7 @@ public class FeedServiceTest {
         User searchedUser = User.builder().username("searchedUserUserName").build();
 
         when(userRepository.findByUsername(me.getUsername())).thenReturn(Optional.of(me));
-        when(followRepository.existsFollowsByFollowedIdAndFollowingId(me.getId(), searchedUser.getId())).thenReturn(true);
+        when(followRepository.existsFollowsByFollowingIdAndFollowedId(me.getId(), searchedUser.getId())).thenReturn(true);
 
         List<SearchUserResponseDto> returnResult = new ArrayList<>();
         returnResult.add(SearchUserResponseDto.builder().build());


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #280 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
Spring Data JPA 에서 parameter 순서를 착각해서, boolean이 반대로 나오는 버그 해결했습니다.
- existsFollowsByFollowedIdAndFollowingId
- existsFollowsByFollowingIdAndFollowedId