### PR TITLE
fix: hot-fix thumbnail path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 |[깻묵](https://github.com/JinuCheon)|[맛동산](https://github.com/https://github.com/MinwuTheQuant)|[마틴](https://github.com/Martin0o0)|
 |:-:|:-:|:-:|
-|<img src="https://avatars.githubusercontent.com/u/76773202?v=4" alt="깻묵" width="100" height="100">|<img src="" alt="맛동산" width="100" height="100">|<img src="" alt="마틴" width="100" height="100">||
+|<img src="https://avatars.githubusercontent.com/u/76773202?v=4" alt="깻묵" width="100" height="100">|<img src="" alt="맛동산" width="100" height="100">|<img src="https://avatars.githubusercontent.com/u/62254434?v=4" alt="마틴" width="100" height="100">||
 
 ## Infra
 ![image](https://user-images.githubusercontent.com/76773202/185728490-54445c41-c109-4860-9422-050e6b50cf76.png)

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -4,10 +4,8 @@ import com.dope.breaking.domain.media.Media;
 import com.dope.breaking.domain.media.MediaType;
 import com.dope.breaking.domain.media.UploadType;
 import com.dope.breaking.domain.post.Post;
-import com.dope.breaking.exception.BreakingException;
 import com.dope.breaking.exception.CustomInternalErrorException;
 import com.dope.breaking.repository.MediaRepository;
-import io.jsonwebtoken.Header;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -17,14 +15,12 @@ import net.bramp.ffmpeg.FFprobe;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
 import net.coobird.thumbnailator.Thumbnails;
 import net.coobird.thumbnailator.geometry.Positions;
-import org.apache.coyote.Response;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.MimeType;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -37,7 +33,6 @@ import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -362,10 +357,10 @@ public class MediaService {
 
                 String videofile = originalMediaPath.getPath();
                 generateThumbFileName = "s_" + UUID.randomUUID().toString() + ".png";
-                String thumbDestinationPath = MAIN_DIR_NAME + SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
+                String thumbDestinationPath = SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
                 FFmpegBuilder fFmpegBuilder = new FFmpegBuilder()
                         .setInput(videofile)
-                        .addOutput(thumbDestinationPath)
+                        .addOutput(MAIN_DIR_NAME + thumbDestinationPath)
                         .addExtraArgs("-ss", "00:00:01")
                         .addExtraArgs("-preset", "ultrafast")
                         .setFrames(1)
@@ -374,7 +369,7 @@ public class MediaService {
                 FFmpegExecutor executor = new FFmpegExecutor(fFmpeg, fFprobe);
                 executor.createJob(fFmpegBuilder).run();
 
-                File thumbDestination = new File(thumbDestinationPath);
+                File thumbDestination = new File(MAIN_DIR_NAME + thumbDestinationPath);
                 BufferedImage tImage = new BufferedImage(tWidth, tHeight, BufferedImage.TYPE_3BYTE_BGR); // 썸네일이미지
                 Graphics2D graphic = tImage.createGraphics();
                 BufferedImage oImage = ImageIO.read(thumbDestination);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #288

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
피드에서 json body 중 thumbnailImgURL key값의 value부분이 필요가 없는 전체 경로로 반환되어 필요한 경로 부분만 추출하여 반환하도록 수정하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="782" alt="스크린샷 2022-08-29 오전 10 37 14" src="https://user-images.githubusercontent.com/62254434/187107991-5d217172-3b4e-4ea2-8e49-c839fda5b5ee.png">
<img width="1795" alt="스크린샷 2022-08-29 오전 10 36 57" src="https://user-images.githubusercontent.com/62254434/187108045-a74955ed-ce36-4a04-8d9f-a4d7e632f36a.png">
<img width="767" alt="스크린샷 2022-08-29 오전 10 36 01" src="https://user-images.githubusercontent.com/62254434/187108090-995dd0a9-f58f-46ba-b994-463d230a780a.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
워터마크 부분에서 한글이 깨져서 보이는 부분을 수정하도록 하겠습니다. 