### PR TITLE
fix: add ec2 front url to allowedOrigins for cors policy

### DIFF
--- a/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
@@ -11,7 +11,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) { //CORS 정책 추가.
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:8080", "https://team-dope.link:8443", "http://localhost:3000", "https://localhost:3000")
+                .allowedOrigins("http://localhost:8080", "http://localhost:3000", "http://team-dope.link:3000")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .exposedHeaders("*")

--- a/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebSecurityConfig.java
@@ -87,7 +87,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.setAllowedOrigins(List.of("http://localhost:8080", "https://team-dope.link:8443", "http://localhost:3000", "https://localhost:3000"));
+        configuration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:3000", "http://team-dope.link:3000"));
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.addExposedHeader("*");


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #291 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항

cors 정책 허용을 위해, allowedOrigins 에 "http://team-dope.link:3000" 를 추가했습니다.

https 적용을 위한 loadbalancer 때문에 혼동이 있었습니다.
실제로 데이터를 받는 곳은 load balancer를 거쳐서 https://team-dope.link:443 이지만,

response header는 servlet layer 또는 front 서버 툴(현재 nginx)에서 만들어지기 때문에,
ec2 내부 주소인 http://team-dope.link:3000 가 header에 들어가게 됩니다.

그래서 cors 허용 출처를 내부 서버로 적어줘야 작동합니다.

![image](https://user-images.githubusercontent.com/76773202/187118579-cc4c8574-9e2e-4736-9932-dcb0d66df821.png)
