### PR TITLE
fix: modify image-ratio to original-ratio with 400x300

### DIFF
--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -264,7 +264,7 @@ public class MediaService {
                     int originalWidth = oImage.getWidth();
                     Thumbnails.of(oImage)
                             .size(originalWidth, originalHeight)
-                            .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1f)
+                            .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1.0f)
                             .outputQuality(1.0f)
                             .toFile(thumbDestination);
 
@@ -334,7 +334,7 @@ public class MediaService {
 
                 Thumbnails.of(oImage)
                         .size(400, 300)
-                        .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 0.5f)
+                        .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1.0f)
                         .outputQuality(1.0f)
                         .toFile(thumbDestination);
 

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -264,7 +264,7 @@ public class MediaService {
                     int originalWidth = oImage.getWidth();
                     Thumbnails.of(oImage)
                             .size(originalWidth, originalHeight)
-                            .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 0.5f)
+                            .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1f)
                             .outputQuality(1.0f)
                             .toFile(thumbDestination);
 
@@ -323,8 +323,6 @@ public class MediaService {
 
         BufferedImage nicknameTextImage = ImageIO.read(new File(watermarkImageURL));
 
-        final int tWidth = 400;
-        final int tHeight = 300;
 
         try {
             if (mediaType.equals(MediaType.PHOTO)) {
@@ -333,12 +331,8 @@ public class MediaService {
                 String thumbDestinationPath = SUB_DIR_NAME + UploadType.THUMBNAIL_POST_MEDIA.getDirName() + File.separator + generateThumbFileName;
                 File thumbDestination = new File(MAIN_DIR_NAME + thumbDestinationPath);
                 BufferedImage oImage = ImageIO.read(originalMediaPath);
-                BufferedImage tImage = new BufferedImage(tWidth, tHeight, BufferedImage.TYPE_3BYTE_BGR);
-                Graphics2D graphic = tImage.createGraphics();
-                Image image = oImage.getScaledInstance(tWidth, tHeight, Image.SCALE_SMOOTH);
-                graphic.drawImage(image, 0, 0, tWidth, tHeight, null);
-                graphic.dispose();
-                Thumbnails.of(tImage)
+
+                Thumbnails.of(oImage)
                         .size(400, 300)
                         .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 0.5f)
                         .outputQuality(1.0f)
@@ -370,14 +364,11 @@ public class MediaService {
                 executor.createJob(fFmpegBuilder).run();
 
                 File thumbDestination = new File(MAIN_DIR_NAME + thumbDestinationPath);
-                BufferedImage tImage = new BufferedImage(tWidth, tHeight, BufferedImage.TYPE_3BYTE_BGR); // 썸네일이미지
-                Graphics2D graphic = tImage.createGraphics();
-                BufferedImage oImage = ImageIO.read(thumbDestination);
-                Image image = oImage.getScaledInstance(tWidth, tHeight, Image.SCALE_SMOOTH);
-                graphic.drawImage(image, 0, 0, tWidth, tHeight, null);
-                graphic.dispose();
 
-                Thumbnails.of(tImage)
+
+                BufferedImage oImage = ImageIO.read(thumbDestination);
+
+                Thumbnails.of(oImage)
                         .size(400, 300)
                         .watermark(Positions.BOTTOM_RIGHT, nicknameTextImage, 1.0f)
                         .outputQuality(1.0f)


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #293 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
썸네일 이미지 생성 시, 원본 비율에 맞춰 생성합니다. 가로가 더 길다면, 400 x * px로, 세로가 더 길다면  * x 300로 비율이 맞춰집니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![s_e5186584-d8a2-412d-bfd5-d90bad2ad8f9](https://user-images.githubusercontent.com/62254434/187138210-3f9f98e1-3a85-40fd-a025-505f44982bf1.png)
![s_6f9b84ae-789b-439b-a604-34cff746e368](https://user-images.githubusercontent.com/62254434/187138216-c7baa1df-5f0c-4625-8224-5f6d557f36be.png)
![s_7ca4ac3a-6551-43df-a01f-a6f49c8a92e3](https://user-images.githubusercontent.com/62254434/187138239-b6f33f3d-1c40-4041-824c-5d3a0817d1b1.png)
![s_8cea71c0-d9f3-4a05-a6e8-ccf921233e56](https://user-images.githubusercontent.com/62254434/187138251-b5925244-9f1a-4a27-984a-8dd01eb59ade.png)



## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
