### PR TITLE
chore: set up spring time zone

### DIFF
--- a/src/main/java/com/dope/breaking/BreakingApplication.java
+++ b/src/main/java/com/dope/breaking/BreakingApplication.java
@@ -9,6 +9,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import javax.annotation.PostConstruct;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 @EnableJpaAuditing
@@ -39,7 +41,10 @@ public class BreakingApplication implements WebMvcConfigurer {
 				.setCacheControl(CacheControl.maxAge(2, TimeUnit.HOURS).cachePublic());
 	}
 
-
+	@PostConstruct
+	public void started() {
+		TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(BreakingApplication.class, args);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #299 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->

스프링 자체의 time zone을 서울로 변경했습니다.

자동 생성되는 createdTime 은 db 시간에 맞춰서 생성이 되는 것이 아닌,
JPA 레벨에서 생성이 되는 것으로 추측됩니다.
그래서 ec2 자체 시간이나 db 시간을 변경해도 createdTime이 변경되지 않았습니다.