### PR TITLE
fix: change security options for cors

### DIFF
--- a/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
+++ b/src/main/java/com/dope/breaking/security/config/WebMvcConfig.java
@@ -1,6 +1,7 @@
 package com.dope.breaking.security.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -11,10 +12,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) { //CORS 정책 추가.
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:8080", "http://localhost:3000", "http://team-dope.link:3000")
-                .allowedMethods("POST", "GET", "PUT", "DELETE")
-                .allowedHeaders("authorization", "authorization-refresh", "User-Agent")
-                .exposedHeaders("authorization", "authorization-refresh", "User-Agent")
+                .allowedOrigins("http://localhost:3000", "http://team-dope.link:3000", "https://team-dope.link")
+                .allowedHeaders("authorization", "authorization-refresh", "User-Agent", "Cache-Control", "Content-Type")
+                .exposedHeaders("authorization", "authorization-refresh", "User-Agent", "Cache-Control", "Content-Type")
+                .allowedMethods("*")
                 .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #304 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->

### 기존에 누락된 부분들
1. allowedMethods 에서, OPTIONS 메소드를 허용하지 않음. 기존에 security에서 options 요청에 대해 허용한 것은, 권한이나 인증에 대한 filter를 skip 하는 것이고, 이와는 별개임.
2. ExposeHeaders를 설정할 때, 브라우저 또는 서버에서 자동으로 생성되는 헤더에 대해서 허용해줘야함. 'Content-Type'에 대한 옵션이 빠져있었음.