### PR TITLE
chore: change basic ffmpeg path for linux

### DIFF
--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -15,6 +15,7 @@ import net.bramp.ffmpeg.FFprobe;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
 import net.coobird.thumbnailator.Thumbnails;
 import net.coobird.thumbnailator.geometry.Positions;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -48,9 +49,14 @@ public class MediaService {
 
     private final MediaRepository mediaRepository;
 
+    @Value("${imageModule.ffmpeg.path}")
+    private String ffmpegPath;
+
+    @Value("${imageModule.ffprobe.path}")
+    private String ffprobePath;
+
     private final String MAIN_DIR_NAME = System.getProperty("user.dir") + "/src/main/webapp/WEB-INF";
     private final String SUB_DIR_NAME = "/static";
-
 
     private final String basicProfileDir = "profile.png";
 
@@ -271,14 +277,8 @@ public class MediaService {
 
                     watermarkMedia.add(watermarkDestinationPath);
                 } else {
-                    //MacOS
-                    FFmpeg fFmpeg = new FFmpeg("/usr/local/bin/ffmpeg");
-                    FFprobe fFprobe = new FFprobe("/usr/local/bin/ffprobe");
-
-                    //UbuntuOS
-//                FFmpeg fFmpeg = new FFmpeg("/usr/bin/ffmpeg");
-//                FFprobe fFprobe = new FFprobe("/usr/bin/ffprobe");
-
+                    FFmpeg fFmpeg = new FFmpeg(ffmpegPath);
+                    FFprobe fFprobe = new FFprobe(ffprobePath);
 
                     String videofile = originalMediaPath.getPath();
                     String generateWatermarkName = "w_" + pathArray[pathArray.length - 1];
@@ -297,7 +297,6 @@ public class MediaService {
                     watermarkMedia.add(watermarkDestinationPath);
                 }
             } catch (IllegalArgumentException e) {
-                e.getMessage();
                 log.info("미디어 포맷을 읽을 수 없습니다.");
                 return null;
             }
@@ -340,14 +339,8 @@ public class MediaService {
 
                 return thumbDestinationPath;
             } else {
-                //MacOS
-                FFmpeg fFmpeg = new FFmpeg("/usr/local/bin/ffmpeg");
-                FFprobe fFprobe = new FFprobe("/usr/local/bin/ffprobe");
-
-                //UbuntuOS
-//                FFmpeg fFmpeg = new FFmpeg("/usr/bin/ffmpeg");
-//                FFprobe fFprobe = new FFprobe("/usr/bin/ffprobe");
-
+                FFmpeg fFmpeg = new FFmpeg(ffmpegPath);
+                FFprobe fFprobe = new FFprobe(ffprobePath);
 
                 String videofile = originalMediaPath.getPath();
                 generateThumbFileName = "s_" + UUID.randomUUID().toString() + ".png";
@@ -378,7 +371,6 @@ public class MediaService {
                 return thumbDestinationPath;
             }
         } catch (IllegalArgumentException e) {
-            e.getMessage();
             log.info("미디어 포맷을 읽을 수 없습니다.");
             return null;
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,3 +39,17 @@ server:
   compression:
     enabled: true
     mime-types: text/html,text/plain,text/css,application/javascript,application/json, application/zip, application/octet-stream
+
+# Linux
+imageModule:
+  ffmpeg:
+    path: "/usr/bin/ffmpeg"
+  ffprobe:
+    path: "/usr/bin/ffprobe"
+
+# MacOS
+#imageModule:
+#  ffmpeg:
+#    path: "/usr/local/bin/ffmpeg"
+#  ffprobe:
+#    path: "/usr/local/bin/ffprobe"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,4 +32,16 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
 
+# Linux
+imageModule:
+  ffmpeg:
+    path: "/usr/bin/ffmpeg"
+  ffprobe:
+    path: "/usr/bin/ffprobe"
 
+# MacOS
+#imageModule:
+#  ffmpeg:
+#    path: "/usr/local/bin/ffmpeg"
+#  ffprobe:
+#    path: "/usr/local/bin/ffprobe"


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #306 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 기존 ffmpeg 모듈 path 기준을 linux 기준으로 설정했습니다.
- path를 설정파일로 분리했습니다.

다른 path들도 운영체제 및 환경에 따라 변경되어야 할 것이 있다면,
설정파일로 분리하는게 좋을 것 같습니다.