### PR TITLE
feat: delete the HttpOnly-Cookie when logging out

### DIFF
--- a/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
+++ b/src/main/java/com/dope/breaking/api/JwtAuthenticationAPI.java
@@ -56,8 +56,8 @@ public class JwtAuthenticationAPI {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/oauth2/sign-out")
-    public ResponseEntity<Void> logout(@RequestHeader(value = "authorization") String accessToken) throws IOException {
-        jwtAuthenticationService.logout(accessToken);
+    public ResponseEntity<Void> logout(@RequestHeader(value = "authorization") String accessToken, HttpServletResponse httpServletResponse) throws IOException {
+        jwtAuthenticationService.logout(accessToken, httpServletResponse);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
+++ b/src/main/java/com/dope/breaking/service/JwtAuthenticationService.java
@@ -83,12 +83,22 @@ public class JwtAuthenticationService {
     }
 
 
-    public void logout(String accessToken) throws IOException {
+    public void logout(String accessToken, HttpServletResponse httpServletResponse) throws IOException {
+
         String getAccessToken = jwtTokenProvider.extractAccessToken(accessToken).orElse(null);
 
         String username = jwtTokenProvider.getUsername(getAccessToken);
         String userAgentType = jwtTokenProvider.getUserAgent(getAccessToken);
-        log.info(userAgentType);
+
+        if(userAgentType.equals("WEB")){
+            Cookie cookie= new Cookie("authorization-refresh", null);
+            cookie.setMaxAge(0);
+            cookie.setHttpOnly(true);
+            cookie.setPath("/");
+            httpServletResponse.addCookie(cookie);
+        }
+
+
         redisService.deleteValues(userAgentType + "_" + username); //레디스에 저장된 refreshToken 삭제
 
         Long expiration = jwtTokenProvider.getExpireTime(getAccessToken);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #303 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에는 로그아웃 시 쿠키가 유지된 채 삭제가 되지 않았습니다. 따라서 기존에 발급받은 HttpOnly Cookie를 삭제하는 기능을 구현하였습니다. ExpireTime을 0으로 지정해줌으로써 자동 소멸하도록 구현하였습니다. 따라서, 로그아웃 시 쿠키가 잔존하지 않고, 소멸됩니다. 

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
1. 쿠키 발급  
<img width="1724" alt="스크린샷 2022-09-03 오후 4 13 32" src="https://user-images.githubusercontent.com/62254434/188260559-41b32bb6-cb98-4d37-830d-08caec8af635.png">

2. 쿠키 삭제 
<img width="1715" alt="스크린샷 2022-09-03 오후 4 13 53" src="https://user-images.githubusercontent.com/62254434/188260566-64ec0b31-25dc-4935-badb-344870e9842b.png">



## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
웹 브라우저(User-Agent : Mozilla/5.0 *)에만 적용되는 사항입니다. 