### PR TITLE
fix: fix post-media file compression error

### DIFF
--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -432,21 +432,25 @@ public class MediaService {
 
         httpServletResponse.setContentType("application/zip");
         httpServletResponse.setHeader("Content-Disposition", "attachment; filename=download.zip");
+        log.info(Integer.toString(mediaURL.size()));
 
+        try (ZipOutputStream zipOutputStream = new ZipOutputStream(httpServletResponse.getOutputStream())) {
 
-        for (String fileName : mediaURL) {
-            ZipOutputStream zipOutputStream = new ZipOutputStream(httpServletResponse.getOutputStream());
-            FileSystemResource fileSystemResource = new FileSystemResource(MAIN_DIR_NAME + SUB_DIR_NAME + UploadType.POST_MEDIA_DOWNLOAD.getDirName() + File.separator + fileName);
-            ZipEntry zipEntry = new ZipEntry(fileSystemResource.getFilename());
-            zipEntry.setSize(fileSystemResource.contentLength());
-            zipEntry.setTime(System.currentTimeMillis());
+            for (String filename : mediaURL) {
+                FileSystemResource fileSystemResource = new FileSystemResource(MAIN_DIR_NAME + SUB_DIR_NAME + UploadType.POST_MEDIA_DOWNLOAD.getDirName() + File.separator + filename);
+                ZipEntry zipEntry = new ZipEntry(fileSystemResource.getFilename());
+                zipEntry.setSize(fileSystemResource.contentLength());
+                zipEntry.setTime(System.currentTimeMillis());
 
-            zipOutputStream.putNextEntry(zipEntry);
+                zipOutputStream.putNextEntry(zipEntry);
 
-            StreamUtils.copy(fileSystemResource.getInputStream(), zipOutputStream);
-            zipOutputStream.closeEntry();
+                StreamUtils.copy(fileSystemResource.getInputStream(), zipOutputStream);
+                zipOutputStream.closeEntry();
+            }
             zipOutputStream.finish();
-
+        } catch (IOException e) {
+            log.info(e.getMessage());
+            throw new CustomInternalErrorException("파일을 다운로드 할 수 없습니다.");
         }
     }
 

--- a/src/main/java/com/dope/breaking/service/MediaService.java
+++ b/src/main/java/com/dope/breaking/service/MediaService.java
@@ -432,7 +432,6 @@ public class MediaService {
 
         httpServletResponse.setContentType("application/zip");
         httpServletResponse.setHeader("Content-Disposition", "attachment; filename=download.zip");
-        log.info(Integer.toString(mediaURL.size()));
 
         try (ZipOutputStream zipOutputStream = new ZipOutputStream(httpServletResponse.getOutputStream())) {
 

--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -286,8 +286,10 @@ public class PostService {
         for (Media mediaURL : mediaList) {
             String[] pathArray = mediaURL.getMediaURL().split("/");
             String watermarkedMediaFileName = pathArray[pathArray.length - 1];
-            String originalMediaFileName = watermarkedMediaFileName.replace("w_", "");
-            mediaURLList.add(originalMediaFileName);
+            if(watermarkedMediaFileName.startsWith("w_")){
+                String originalMediaFileName = watermarkedMediaFileName.replace("w_", "");
+                mediaURLList.add(originalMediaFileName);
+            }
         }
 
         mediaService.responseAllMediaFile(mediaURLList, httpServletResponse);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #296 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
파일 압축 손상에 대한 원인을 발견하여 급히 핫-픽스하였습니다. 기존에 코드에서(PostService-289line) 원본 파일에 대한 경로를 담는 리스트에서 동일한 원본 파일을 두번이나 담는 현상을 발견하였고, 이는 mediaService에서 압축하는 과정에서 duplicate entry 에러를 계속해서 반환하고 있었습니다. 이에 따라, 원본 파일을 한번만 담도록 수정하였으며, try-catch-resouce문으로 압축하는 방식으로 수정하였습니다. 이에따라 정상적으로 파일이 압축되어 다운받아 질 것으로 예상합니다. 

이와 관련하여 참고한 레퍼런스는 다음과 같습니다.
1. https://infiduk.github.io/2020/04/27/java.html
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="807" alt="스크린샷 2022-09-03 오후 6 18 29" src="https://user-images.githubusercontent.com/62254434/188264428-7f77968c-14f7-4a28-aa59-1631466b2aa0.png">

<img width="497" alt="스크린샷 2022-09-03 오후 6 18 38" src="https://user-images.githubusercontent.com/62254434/188264433-6b8b9b1b-c39a-4d48-8664-bc69d5bf4b4e.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
저번에 클라이언트에서 동일한 파일이 두번이나 받아져 온다는 것을 확인하고, 살펴보니 로직에서 문제점이 발견되었고, 급히 수정하였습니다. 