### PR TITLE
feat: add view count to breaking mission

### DIFF
--- a/src/main/java/com/dope/breaking/api/MissionAPI.java
+++ b/src/main/java/com/dope/breaking/api/MissionAPI.java
@@ -64,7 +64,7 @@ public class MissionAPI {
         if(principal != null){
             username = principal.getName();
         }
-        return missionService.readMission(missionId, username);
+        return ResponseEntity.ok().body(missionService.readMission(missionId, username));
     }
 
     @GetMapping("/breaking-mission/{missionId}/feed")

--- a/src/main/java/com/dope/breaking/domain/post/Mission.java
+++ b/src/main/java/com/dope/breaking/domain/post/Mission.java
@@ -26,7 +26,7 @@ public class Mission {
 
     private String content;
 
-    private Long viewCount;
+    private Long viewCount = 0L;
 
     private LocalDateTime startTime;
 

--- a/src/main/java/com/dope/breaking/domain/post/Mission.java
+++ b/src/main/java/com/dope/breaking/domain/post/Mission.java
@@ -26,6 +26,8 @@ public class Mission {
 
     private String content;
 
+    private Long viewCount;
+
     private LocalDateTime startTime;
 
     private LocalDateTime endTime;
@@ -41,6 +43,10 @@ public class Mission {
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = location;
+    }
+
+    public void increaseViewCount() {
+        viewCount++;
     }
 
 }

--- a/src/main/java/com/dope/breaking/dto/mission/MissionFeedResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/mission/MissionFeedResponseDto.java
@@ -19,6 +19,8 @@ public class MissionFeedResponseDto {
 
     private String title;
 
+    private Long viewCount;
+
     private LocalDateTime startTime;
 
     private LocalDateTime endTime;
@@ -30,9 +32,10 @@ public class MissionFeedResponseDto {
     private Boolean isMyMission;
 
     @QueryProjection
-    public MissionFeedResponseDto(Long missionId, String title, LocalDateTime startTime, LocalDateTime endTime, LocationDto location, WriterDto user, Boolean isMyMission) {
+    public MissionFeedResponseDto(Long missionId, String title, Long viewCount, LocalDateTime startTime, LocalDateTime endTime, LocationDto location, WriterDto user, Boolean isMyMission) {
         this.missionId = missionId;
         this.title = title;
+        this.viewCount = viewCount;
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = location;

--- a/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/mission/MissionResponseDto.java
@@ -23,20 +23,22 @@ public class MissionResponseDto {
 
     String content;
 
+    Long viewCount;
+
     LocalDateTime startTime;
 
     LocalDateTime endTime;
-
 
     LocationDto location;
 
     WriterDto user;
 
     @Builder
-    public MissionResponseDto(String title, String content, LocalDateTime startTime, LocalDateTime endTime, Boolean isMyMission, LocationDto locationDto, WriterDto writerDto){
+    public MissionResponseDto(String title, String content, Long viewCount, LocalDateTime startTime, LocalDateTime endTime, Boolean isMyMission, LocationDto locationDto, WriterDto writerDto){
         this.isMyMission = isMyMission;
         this.title = title;
         this.content = content;
+        this.viewCount = viewCount;
         this.startTime = startTime;
         this.endTime = endTime;
         this.location = locationDto;

--- a/src/main/java/com/dope/breaking/repository/MissionRepositoryCustomImpl.java
+++ b/src/main/java/com/dope/breaking/repository/MissionRepositoryCustomImpl.java
@@ -31,6 +31,7 @@ public class MissionRepositoryCustomImpl implements MissionRepositoryCustom{
                 .select(new QMissionFeedResponseDto(
                         mission.id,
                         mission.title,
+                        mission.viewCount,
                         mission.startTime,
                         mission.endTime,
                         new QLocationDto(

--- a/src/main/java/com/dope/breaking/service/MissionService.java
+++ b/src/main/java/com/dope/breaking/service/MissionService.java
@@ -94,44 +94,39 @@ public class MissionService {
 
     }
 
-    public ResponseEntity<MissionResponseDto> readMission(long missionId, String crntUsername){
+    public MissionResponseDto readMission(long missionId, String username){
 
-        //예외처리 수정 필요
-        Mission mission = missionRepository.findById(missionId).orElseThrow(() -> new NoSuchBreakingMissionException());
-
+        Mission mission = missionRepository.findById(missionId).orElseThrow(NoSuchBreakingMissionException::new);
+        mission.increaseViewCount();
 
         boolean isMyMission = false;
-        if(crntUsername != null){
-            User user = userRepository.findByUsername(crntUsername).get();
-            isMyMission = user == mission.getUser(); //JPA의 동일성 보장
+        if(username != null){
+            User user = userRepository.findByUsername(username).get();
+            isMyMission = user == mission.getUser();
         }
 
-        LocationDto locationDto = LocationDto.builder()
-                .address(mission.getLocation().getAddress())
-                .latitude(mission.getLocation().getLatitude())
-                .longitude(mission.getLocation().getLongitude())
-                .region_1depth_name(mission.getLocation().getRegion_1depth_name())
-                .region_2depth_name(mission.getLocation().getRegion_2depth_name()).build();
-
-
-        User missionWriter = mission.getUser();
-        WriterDto writerDto = WriterDto.builder()
-                .userId(missionWriter.getId())
-                .profileImgURL(missionWriter.getOriginalProfileImgURL())
-                .nickname(missionWriter.getNickname()).build();
-
-
-        MissionResponseDto missionResponseDto = MissionResponseDto.builder()
+        return MissionResponseDto.builder()
                 .isMyMission(isMyMission)
                 .title(mission.getTitle())
+                .viewCount(mission.getViewCount())
                 .content(mission.getContent())
                 .startTime(mission.getStartTime())
                 .endTime(mission.getEndTime())
-                .locationDto(locationDto)
-                .writerDto(writerDto)
+                .locationDto(
+                        LocationDto.builder()
+                                .address(mission.getLocation().getAddress())
+                                .latitude(mission.getLocation().getLatitude())
+                                .longitude(mission.getLocation().getLongitude())
+                                .region_1depth_name(mission.getLocation().getRegion_1depth_name())
+                                .region_2depth_name(mission.getLocation().getRegion_2depth_name()).build()
+                )
+                .writerDto(
+                        WriterDto.builder()
+                                .userId(mission.getUser().getId())
+                                .profileImgURL(mission.getUser().getOriginalProfileImgURL())
+                                .nickname(mission.getUser().getNickname()).build()
+                )
                 .build();
-
-        return new ResponseEntity<MissionResponseDto>(missionResponseDto, HttpStatus.OK);
 
     }
     

--- a/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
+++ b/src/test/java/com/dope/breaking/repository/MissionRepositoryTest.java
@@ -2,8 +2,11 @@ package com.dope.breaking.repository;
 
 import com.dope.breaking.domain.post.Location;
 import com.dope.breaking.domain.post.Mission;
+import com.dope.breaking.domain.post.PostType;
 import com.dope.breaking.domain.user.User;
 import com.dope.breaking.dto.mission.MissionFeedResponseDto;
+import com.dope.breaking.dto.post.FeedResultPostDto;
+import com.dope.breaking.dto.post.SearchFeedConditionDto;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -108,6 +111,47 @@ class MissionRepositoryTest {
         assertEquals(1, result.size());
         assertTrue(result.get(0).getIsMyMission());
 
+    }
+
+
+    @DisplayName("유저가 조회한 게시글은 조회수가 증가한다.")
+    @Test
+    void missionViewCountIncrement() {
+
+        User missionOwner = new User();
+        userRepository.save(missionOwner);
+
+        Mission mission = Mission.builder()
+                .user(missionOwner)
+                .build();
+        missionRepository.save(mission);
+
+        mission.increaseViewCount();
+        mission.increaseViewCount();
+        mission.increaseViewCount();
+
+        assertEquals(3, mission.getViewCount());
+    }
+
+    @DisplayName("유저가 조회한 미션은 미션 피드에서 조회수가 증가한다.")
+    @Test
+    void missionViewCountIncrementOnFeed() {
+
+        User missionOwner = new User();
+        userRepository.save(missionOwner);
+
+        Mission mission = Mission.builder()
+                .user(missionOwner)
+                .build();
+        missionRepository.save(mission);
+
+        mission.increaseViewCount();
+        mission.increaseViewCount();
+        mission.increaseViewCount();
+
+        List<MissionFeedResponseDto> result = missionRepository.searchMissionFeed(null, null, 20L);
+
+        assertEquals(3, result.get(0).getViewCount());
     }
 
 }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #313 

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 미션 엔티티에 viewCount 필드가 추가되었습니다.
- 미션 피드에 viewCount 필드가 추가되었습니다.
- 브레이킹 미션에 조회수 기능을 추가했습니다.
- 기존 미션 조회 기능을 리팩토링했습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

response 형태 팀원/과거의 나와 꼭 통일 해주세요..
controller에서 response 하도록.

그리고 불필요한 주석(복잡한 로직이 없어서, 거의 **무조건** 불필요함) 이나 테스트에 사용했던 로그는 지워주세요.