### PR TITLE
refactor: change deactive-purchase http method to delete

### DIFF
--- a/src/main/java/com/dope/breaking/api/PostAPI.java
+++ b/src/main/java/com/dope/breaking/api/PostAPI.java
@@ -70,7 +70,7 @@ public class PostAPI {
     }
 
     @PreAuthorize("isAuthenticated()")
-    @PostMapping("/post/{postId}/deactivate-purchase")
+    @DeleteMapping("/post/{postId}/activate-purchase")
     public ResponseEntity<Void> deactivatePurchase(Principal principal, @PathVariable Long postId){
         postService.deactivatePurchase(principal.getName(),postId);
         return ResponseEntity.ok().build();

--- a/src/test/java/com/dope/breaking/api/PostAPITest.java
+++ b/src/test/java/com/dope/breaking/api/PostAPITest.java
@@ -649,7 +649,7 @@ class PostAPITest {
         Long postId = postRepository.save(post).getId();
 
         //When
-        this.mockMvc.perform(MockMvcRequestBuilders.post("/post/{postId}/deactivate-purchase",postId))
+        this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/{postId}/activate-purchase",postId))
                 .andExpect(status().isOk()); //Then
 
         //Then
@@ -677,7 +677,7 @@ class PostAPITest {
         Long postId = postRepository.save(post).getId();
 
         //When
-        this.mockMvc.perform(MockMvcRequestBuilders.post("/post/{postId}/deactivate-purchase",postId))
+        this.mockMvc.perform(MockMvcRequestBuilders.delete("/post/{postId}/activate-purchase",postId))
                 .andExpect(status().isBadRequest()); //Then
 
     }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #319 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
http method 통일을 위해, 포스트 판매 비활성화 처리의 http method 를 수정합니다.

`POST /post/{postId}/deactivate-purchase`
to
`DELETE /post/{postId}/activate-purchase`