### PR TITLE
feat: add role field to result of validate jwt

### DIFF
--- a/src/main/java/com/dope/breaking/dto/user/UserBriefInformationResponseDto.java
+++ b/src/main/java/com/dope/breaking/dto/user/UserBriefInformationResponseDto.java
@@ -1,5 +1,6 @@
 package com.dope.breaking.dto.user;
 
+import com.dope.breaking.domain.user.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -14,6 +15,8 @@ public class UserBriefInformationResponseDto {
     String nickname;
 
     Long userId;
+
+    Role role;
 
     int balance;
 

--- a/src/main/java/com/dope/breaking/service/UserService.java
+++ b/src/main/java/com/dope/breaking/service/UserService.java
@@ -187,7 +187,7 @@ public class UserService {
     public UserBriefInformationResponseDto userBriefInformation(String username) {
 
         User user = userRepository.findByUsername(username).orElseThrow(InvalidAccessTokenException::new);
-        return new UserBriefInformationResponseDto(user.getCompressedProfileImgURL(), user.getNickname(), user.getId(), user.getBalance());
+        return new UserBriefInformationResponseDto(user.getCompressedProfileImgURL(), user.getNickname(), user.getId(), user.getRole(), user.getBalance());
     }
 
     private SignUpRequestDto transformUserInformationToObject(String signUpRequest) {


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #323 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
 현재 로그인 유저 정보 제공에 role 필드를 추가했습니다
 브레이킹 미션 ui 를 위해 언론사 및 일반 유저 구분이 필요합니다.