### PR TITLE
fix: return a compressed profile image when look-up  post details

### DIFF
--- a/src/main/java/com/dope/breaking/service/PostService.java
+++ b/src/main/java/com/dope/breaking/service/PostService.java
@@ -197,7 +197,7 @@ public class PostService {
         if (!(!isMyPost && post.isAnonymous())) {
             writerDto = WriterDto.builder()
                     .nickname(post.getUser().getNickname())
-                    .profileImgURL(post.getUser().getOriginalProfileImgURL())
+                    .profileImgURL(post.getUser().getCompressedProfileImgURL())
                     .userId(post.getUser().getId()).build();
         }
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #327 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
클라이언트 요청에 따라 게시글 세부 조회 시 작성자의 프로필 이미지를 압축된 이미지로 반환합니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
<img width="864" alt="스크린샷 2022-09-13 오후 12 06 17" src="https://user-images.githubusercontent.com/62254434/189799086-786643ab-1c84-4320-820d-fcc0fb5a87b9.png">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
다음으로 프로필 이미지 압축 처리를 수정합니다.