### PR TITLE
fix: hide anonymous post from guest user

### DIFF
--- a/src/main/java/com/dope/breaking/service/SearchFeedService.java
+++ b/src/main/java/com/dope/breaking/service/SearchFeedService.java
@@ -55,11 +55,12 @@ public class SearchFeedService {
 
         List<FeedResultPostDto> result = feedRepository.searchFeedBy(searchFeedConditionDto, cursorPost, me);
 
-        if(me != null) {
-            for (FeedResultPostDto dto : result) {
-                if (dto.getIsAnonymous()) {
-                    dto.setUser(null);
-                }
+
+        for (FeedResultPostDto dto : result) {
+            if (dto.getIsAnonymous()) {
+                dto.setUser(null);
+            }
+            if(me != null) {
                 dto.setIsBookmarked(bookmarkRepository.existsByUserAndPostId(me, dto.getPostId()));
                 dto.setIsLiked(postLikeRepository.existsByUserAndPostId(me, dto.getPostId()));
             }


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #331 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
로그인 하지 않은 상태에서 피드를 볼 경우,

익명 게시글의 유저가 노출되는 현상 발생했습니다.

로그인 했는지를 판단하는 로직 안에 익명 유저 처리하는 로직이 들어가서 발생한 문제였습니다.

hofix 올립니다.